### PR TITLE
Make the clock interface more idiomatic

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ aggregator service.
 ## Instrumenting Code
 
 ```go
-
 package main
 
 import (
@@ -40,7 +39,7 @@ type Response struct {
 
 func (s *Server) Handle(request *Request) (res *Response) {
 	clock := s.registry.Clock()
-	start := clock.MonotonicTime()
+	start := clock.Now()
 
 	// initialize res
 	res = &Response{200, 64}
@@ -54,7 +53,7 @@ func (s *Server) Handle(request *Request) (res *Response) {
 	s.registry.CounterWithId(cntId).Increment()
 
 	// ...
-	s.requestLatency.Record(clock.MonotonicTime() - start)
+	s.requestLatency.Record(clock.Now().Sub(start))
 	s.responseSizes.Record(res.size)
 	return
 }
@@ -91,6 +90,7 @@ func main() {
 		server.Handle(req)
 	}
 }
+
 ```
 
 

--- a/clock.go
+++ b/clock.go
@@ -3,30 +3,37 @@ package spectator
 import "time"
 
 type Clock interface {
-	WallTime() int64
-	MonotonicTime() time.Duration
+	Now() time.Time
+	Nanos() int64
 }
 
 type SystemClock struct{}
 
-func (c *SystemClock) WallTime() int64 {
-	return int64(c.MonotonicTime()) / 1000000
+func (c *SystemClock) Now() time.Time {
+	return time.Now()
 }
 
-func (c *SystemClock) MonotonicTime() time.Duration {
+func (c *SystemClock) Nanos() int64 {
 	now := time.Now()
-	return time.Duration(now.UnixNano())
+	return now.UnixNano()
 }
 
 type ManualClock struct {
-	wall      int64
-	monotonic time.Duration
+	nanos int64
 }
 
-func (c *ManualClock) WallTime() int64 {
-	return c.wall
+func (c *ManualClock) Now() time.Time {
+	return time.Unix(0, c.nanos)
 }
 
-func (c *ManualClock) MonotonicTime() time.Duration {
-	return c.monotonic
+func (c *ManualClock) Nanos() int64 {
+	return c.nanos
+}
+
+func (c *ManualClock) SetFromDuration(duration time.Duration) {
+	c.nanos = int64(duration)
+}
+
+func (c *ManualClock) SetNanos(nanos int64) {
+	c.nanos = nanos
 }

--- a/http_client.go
+++ b/http_client.go
@@ -69,7 +69,8 @@ func (h *HttpClient) PostJson(uri string, jsonBytes []byte) (statusCode int) {
 		"mode":   "http-client",
 	}
 
-	start := h.registry.clock.MonotonicTime()
+	clock := h.registry.clock
+	start := clock.Now()
 	log.Debugf("posting data to %s, payload %s", uri, string(jsonBytes))
 	resp, err := client.Do(req)
 	if err != nil {
@@ -95,7 +96,7 @@ func (h *HttpClient) PostJson(uri string, jsonBytes []byte) (statusCode int) {
 		log.Debugf("request succeeded (%d): %s", resp.StatusCode, body)
 
 	}
-	duration := h.registry.clock.MonotonicTime() - start
-	h.registry.Timer("http.req.complete", tags).Record(duration)
+	elapsed := clock.Now().Sub(start)
+	h.registry.Timer("http.req.complete", tags).Record(elapsed)
 	return
 }

--- a/registry_test.go
+++ b/registry_test.go
@@ -62,7 +62,7 @@ func TestRegistry_Timer(t *testing.T) {
 
 func TestRegistry_Start(t *testing.T) {
 	r := NewRegistry(config)
-	clock := &ManualClock{1, 1}
+	clock := &ManualClock{1}
 	r.clock = clock
 	r.Counter("foo", nil).Increment()
 	r.Start()
@@ -72,7 +72,7 @@ func TestRegistry_Start(t *testing.T) {
 
 func TestRegistry_publish(t *testing.T) {
 	const StartTime = 1
-	clock := &ManualClock{StartTime, StartTime}
+	clock := &ManualClock{StartTime}
 	publishHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		contentType := r.Header.Get("Content-Type")
 		if contentType != "application/json" {
@@ -104,7 +104,7 @@ func TestRegistry_publish(t *testing.T) {
 
 		w.Write(okMsg)
 
-		clock.monotonic = StartTime + 1000
+		clock.SetNanos(StartTime + 1000)
 	})
 
 	server := httptest.NewServer(publishHandler)


### PR DESCRIPTION
Switches from `MonotonicTime` returning a `time.Duration` to a
`time.Time`, and getting rid of the unused walltime method