### PR TITLE
Add Golang runtime metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ func getNextRequest() *Request {
 	// ...
 	return &Request{"US"}
 }
+
 func main() {
 	commonTags := map[string]string{"nf.app": "example", "nf.region": "us-west-1"}
 	config := &spectator.Config{Frequency: 5 * time.Second, Timeout: 1 * time.Second,
@@ -81,6 +82,9 @@ func main() {
 	// registry.SetLogger(logger)
 	registry.Start()
 	defer registry.Stop()
+
+	// collect memory and file descriptor metrics
+	spectator.CollectRuntimeMetrics(registry)
 
 	server := newServer(registry)
 

--- a/memstats.go
+++ b/memstats.go
@@ -1,0 +1,85 @@
+package spectator
+
+import (
+	"runtime"
+	"time"
+)
+
+type memStatsCollector struct {
+	registry         *Registry
+	bytesAlloc       *Gauge
+	allocationRate   *MonotonicCounter
+	totalBytesSystem *Gauge
+	numLiveObjects   *Gauge
+	objectsAllocated *MonotonicCounter
+	objectsFreed     *MonotonicCounter
+
+	gcLastPauseTimeValue uint64
+	gcPauseTime          *Timer
+	gcAge                *Gauge
+	gcCount              *MonotonicCounter
+	forcedGcCount        *MonotonicCounter
+	gcPercCpu            *Gauge
+}
+
+func memStats(m *memStatsCollector) {
+	var mem runtime.MemStats
+	runtime.ReadMemStats(&mem)
+	updateMemStats(m, &mem)
+}
+
+func updateMemStats(m *memStatsCollector, mem *runtime.MemStats) {
+	m.bytesAlloc.Set(float64(mem.Alloc))
+	m.allocationRate.Set(int64(mem.TotalAlloc))
+	m.totalBytesSystem.Set(float64(mem.Sys))
+	m.numLiveObjects.Set(float64(mem.Mallocs - mem.Frees))
+	m.objectsAllocated.Set(int64(mem.Mallocs))
+	m.objectsFreed.Set(int64(mem.Frees))
+
+	if mem.LastGC != m.gcLastPauseTimeValue {
+		m.gcPauseTime.Record(time.Duration(mem.LastGC - m.gcLastPauseTimeValue))
+		m.gcLastPauseTimeValue = mem.LastGC
+	}
+
+	nanos := m.registry.clock.Nanos()
+	timeSinceLastGC := nanos - int64(mem.LastGC)
+	secondsSinceLastGC := float64(timeSinceLastGC) / 1e9
+	m.gcAge.Set(secondsSinceLastGC)
+
+	m.gcCount.Set(int64(mem.NumGC))
+	m.forcedGcCount.Set(int64(mem.NumForcedGC))
+	m.gcPercCpu.Set(mem.GCCPUFraction * 100)
+}
+
+// Collect memory stats
+// https://golang.org/pkg/runtime/#MemStats
+func CollectMemStats(registry *Registry) {
+	var mem memStatsCollector
+	tags := map[string]string{
+		"id": "memstats",
+	}
+	mem.registry = registry
+	mem.bytesAlloc = registry.Gauge("mem.heapBytesAllocated", tags)
+	mem.allocationRate = NewMonotonicCounter(registry, "mem.allocationRate", tags)
+	mem.totalBytesSystem = registry.Gauge("mem.maxHeapBytes", tags)
+	mem.numLiveObjects = registry.Gauge("mem.numLiveObjects", tags)
+	mem.objectsAllocated = NewMonotonicCounter(registry, "mem.objectsAllocated", tags)
+	mem.objectsFreed = NewMonotonicCounter(registry, "mem.objectsFreed", tags)
+	mem.gcPauseTime = registry.Timer("gc.pauseTime", tags)
+	mem.gcAge = registry.Gauge("gc.timeSinceLastGC", tags)
+	mem.gcCount = NewMonotonicCounter(registry, "gc.count", tags)
+	mem.forcedGcCount = NewMonotonicCounter(registry, "gc.forcedCount", tags)
+	mem.gcPercCpu = registry.Gauge("gc.cpuPercentage", tags)
+
+	ticker := time.NewTicker(30 * time.Second)
+	go func() {
+		log := registry.log
+		for {
+			select {
+			case <-ticker.C:
+				log.Debugf("Collecting memory stats")
+				memStats(&mem)
+			}
+		}
+	}()
+}

--- a/monotonic_counter.go
+++ b/monotonic_counter.go
@@ -4,9 +4,9 @@ import "sync/atomic"
 
 type MonotonicCounter struct {
 	registry *Registry
-	id *Id
-	value int64
-	counter *Counter
+	id       *Id
+	value    int64
+	counter  *Counter
 }
 
 func NewMonotonicCounter(registry *Registry, name string, tags map[string]string) *MonotonicCounter {

--- a/monotonic_counter_test.go
+++ b/monotonic_counter_test.go
@@ -15,7 +15,7 @@ func TestNewMonotonicCounter(t *testing.T) {
 	}
 
 	c.Set(42)
-	if v := c.Count() ; v != 42 {
+	if v := c.Count(); v != 42 {
 		t.Errorf("Expected 42, got %d", v)
 	}
 

--- a/runtime.go
+++ b/runtime.go
@@ -1,0 +1,72 @@
+package spectator
+
+import (
+	"os"
+	"syscall"
+	"time"
+)
+
+func getNumFiles(dir string) int {
+	f, err := os.Open(dir)
+	if err != nil {
+		return 0
+	}
+	defer f.Close()
+	entries, err := f.Readdirnames(-1)
+	if err != nil {
+		return 0
+	}
+	return len(entries)
+}
+
+type fdStatsCollector struct {
+	registry *Registry
+	curOpen  *Gauge
+	maxOpen  *Gauge
+}
+
+func updateFdStats(f *fdStatsCollector, cur int, max uint64) {
+	f.curOpen.Set(float64(cur))
+	f.maxOpen.Set(float64(max))
+}
+
+func fdStats(f *fdStatsCollector) {
+	// do not include /proc/self/fd in the count, since it will be opened
+	// when we get the number of files under self/fd
+	currentFdCount := getNumFiles("/proc/self/fd") - 1
+	var rl syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rl); err != nil {
+		f.registry.log.Errorf("Unable to get max open files")
+	}
+	maxFdCount := rl.Cur
+	updateFdStats(f, currentFdCount, maxFdCount)
+}
+
+// Collects file handle stats
+func CollectFileHandleStats(registry *Registry) {
+	var f fdStatsCollector
+	f.registry = registry
+	tags := map[string]string{
+		"id": "fdstats",
+	}
+	f.maxOpen = registry.Gauge("fh.maxOpen", tags)
+	f.curOpen = registry.Gauge("fh.curOpen", tags)
+
+	ticker := time.NewTicker(30 * time.Second)
+	go func() {
+		log := registry.log
+		for {
+			select {
+			case <-ticker.C:
+				log.Debugf("Collecting file handle stats")
+				fdStats(&f)
+			}
+		}
+	}()
+}
+
+// Starts the collection of memory and file handle metrics
+func CollectRuntimeMetrics(registry *Registry) {
+	CollectMemStats(registry)
+	CollectFileHandleStats(registry)
+}


### PR DESCRIPTION
This is a first pass at providing memory/gc/file handle metrics for golang servers. Names will probably have to be updated.

Use: `spectator.CollectRuntimeMetrics(registry)` to start the collection
of memory and file descriptor metrics for the current process

In the future we'll probably make this the default when you call `registry.Start()`