### PR TITLE
Make meters use a string key, instead of a hash

### DIFF
--- a/dist_summary_test.go
+++ b/dist_summary_test.go
@@ -54,20 +54,20 @@ func assertDistributionSummary(t *testing.T, d *DistributionSummary, count int64
 		t.Error("Expected 4 measurements from a DistributionSummary, got ", len(ms))
 	}
 
-	expected := make(map[uint64]float64)
-	expected[d.id.WithStat("count").Hash()] = float64(count)
-	expected[d.id.WithStat("totalAmount").Hash()] = float64(total)
-	expected[d.id.WithStat("totalOfSquares").Hash()] = totalSq
-	expected[d.id.WithStat("max").Hash()] = float64(max)
+	expected := make(map[string]float64)
+	expected[d.id.WithStat("count").mapKey()] = float64(count)
+	expected[d.id.WithStat("totalAmount").mapKey()] = float64(total)
+	expected[d.id.WithStat("totalOfSquares").mapKey()] = totalSq
+	expected[d.id.WithStat("max").mapKey()] = float64(max)
 
-	got := make(map[uint64]float64)
+	got := make(map[string]float64)
 	for _, v := range ms {
-		got[v.id.Hash()] = v.value
+		got[v.id.mapKey()] = v.value
 	}
 	if !reflect.DeepEqual(got, expected) {
-		t.Error("Expected measurements (count=", count, ",total=", total, ",totalSq=", totalSq, ",max=", max, ")")
+		t.Errorf("Expected measurements (count=%d, total=%d, totalSq=%.0f, max=%d)", count, total, totalSq, max)
 		for _, m := range ms {
-			t.Error("Got ", m.id.name, " ", m.id.tags, "=", m.value)
+			t.Errorf("Got %s %v = %f", m.id.name, m.id.tags, m.value)
 		}
 	}
 

--- a/id_test.go
+++ b/id_test.go
@@ -1,17 +1,43 @@
 package spectator
 
-import "testing"
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
 
-func TestId_Hash(t *testing.T) {
+func TestId_mapKey(t *testing.T) {
 	id := newId("foo", nil)
-	h := id.Hash()
-	if h == 0 {
-		t.Error("Expected a non-zero value, got 0")
+	k := id.mapKey()
+	if k != "foo" {
+		t.Error("Expected foo, got", k)
 	}
 
-	reusesHash := Id{"foo", nil, 1}
-	h2 := reusesHash.Hash()
-	if h2 != 1 {
-		t.Error("Expected 1, got ", h2)
+	reusesKey := Id{"foo", nil, "bar"}
+	k2 := reusesKey.mapKey()
+	if k2 != "bar" {
+		t.Error("Expected mapKey to be reused: bar !=", k2)
+	}
+}
+
+func TestId_mapKeySortsTags(t *testing.T) {
+	tags := make(map[string]string)
+
+	for i := 0; i < 100; i++ {
+		k := fmt.Sprintf("%03d", i)
+		tags[k] = "v"
+	}
+	id := newId("foo", tags)
+	k := id.mapKey()
+
+	var buf bytes.Buffer
+	buf.WriteString("foo")
+	for i := 0; i < 100; i++ {
+		k := fmt.Sprintf("|%03d|v", i)
+		buf.WriteString(k)
+	}
+
+	if k != buf.String() {
+		t.Errorf("Expected %s, got %s", buf.String(), k)
 	}
 }

--- a/registry.go
+++ b/registry.go
@@ -24,7 +24,7 @@ type Config struct {
 type Registry struct {
 	clock   Clock
 	config  *Config
-	meters  map[uint64]Meter
+	meters  map[string]Meter
 	started bool
 	log     Logger
 	mutex   *sync.Mutex
@@ -50,7 +50,7 @@ func NewRegistryConfiguredBy(filePath string) (*Registry, error) {
 }
 
 func NewRegistry(config *Config) *Registry {
-	r := &Registry{&SystemClock{}, config, map[uint64]Meter{}, false,
+	r := &Registry{&SystemClock{}, config, map[string]Meter{}, false,
 		defaultLogger(), &sync.Mutex{}, nil, make(chan struct{})}
 	r.http = NewHttpClient(r, r.config.Timeout)
 	return r
@@ -235,10 +235,10 @@ type meterFactoryFun func() Meter
 func (r *Registry) newMeter(id *Id, meterFactory meterFactoryFun) Meter {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
-	meter, exists := r.meters[id.Hash()]
+	meter, exists := r.meters[id.mapKey()]
 	if !exists {
 		meter = meterFactory()
-		r.meters[id.Hash()] = meter
+		r.meters[id.mapKey()] = meter
 	}
 	return meter
 }

--- a/timer_test.go
+++ b/timer_test.go
@@ -52,20 +52,20 @@ func assertTimer(t *testing.T, timer *Timer, count int64, total int64, totalSq f
 		t.Error("Expected 4 measurements from a Timer, got ", len(ms))
 	}
 
-	expected := make(map[uint64]float64)
-	expected[timer.id.WithStat("count").Hash()] = float64(count)
-	expected[timer.id.WithStat("totalTime").Hash()] = float64(total) / 1e9
-	expected[timer.id.WithStat("totalOfSquares").Hash()] = totalSq / 1e18
-	expected[timer.id.WithStat("max").Hash()] = float64(max) / 1e9
+	expected := make(map[string]float64)
+	expected[timer.id.WithStat("count").mapKey()] = float64(count)
+	expected[timer.id.WithStat("totalTime").mapKey()] = float64(total) / 1e9
+	expected[timer.id.WithStat("totalOfSquares").mapKey()] = totalSq / 1e18
+	expected[timer.id.WithStat("max").mapKey()] = float64(max) / 1e9
 
-	got := make(map[uint64]float64)
+	got := make(map[string]float64)
 	for _, v := range ms {
-		got[v.id.Hash()] = v.value
+		got[v.id.mapKey()] = v.value
 	}
 	if !reflect.DeepEqual(got, expected) {
 		t.Errorf("Expected measurements (count=%d, total=%d, totalSq=%.0f, max=%d)", count, total, totalSq, max)
 		for _, m := range ms {
-			t.Error("Got ", m.id.name, " ", m.id.tags, "=", m.value)
+			t.Errorf("Got %s %v = %f", m.id.name, m.id.tags, m.value)
 		}
 	}
 


### PR DESCRIPTION
We were using the lower 64 bits of the md5 of the name and tags as the
map key. It is very unlikely that it will cause collisions with normal
data, but if it did it would be very hard to debug. Replace the hash
with the concatenation of the name and sorted tags as the key.