### PR TITLE
Update runtime metric names

### DIFF
--- a/memstats.go
+++ b/memstats.go
@@ -51,21 +51,18 @@ func updateMemStats(m *memStatsCollector, mem *runtime.MemStats) {
 }
 
 func initializeMemStatsCollector(registry *Registry, mem *memStatsCollector) {
-	tags := map[string]string{
-		"id": "memstats",
-	}
 	mem.registry = registry
-	mem.bytesAlloc = registry.Gauge("mem.heapBytesAllocated", tags)
-	mem.allocationRate = NewMonotonicCounter(registry, "mem.allocationRate", tags)
-	mem.totalBytesSystem = registry.Gauge("mem.maxHeapBytes", tags)
-	mem.numLiveObjects = registry.Gauge("mem.numLiveObjects", tags)
-	mem.objectsAllocated = NewMonotonicCounter(registry, "mem.objectsAllocated", tags)
-	mem.objectsFreed = NewMonotonicCounter(registry, "mem.objectsFreed", tags)
-	mem.gcPauseTime = registry.Timer("gc.pauseTime", tags)
-	mem.gcAge = registry.Gauge("gc.timeSinceLastGC", tags)
-	mem.gcCount = NewMonotonicCounter(registry, "gc.count", tags)
-	mem.forcedGcCount = NewMonotonicCounter(registry, "gc.forcedCount", tags)
-	mem.gcPercCpu = registry.Gauge("gc.cpuPercentage", tags)
+	mem.bytesAlloc = registry.Gauge("mem.heapBytesAllocated", nil)
+	mem.allocationRate = NewMonotonicCounter(registry, "mem.allocationRate", nil)
+	mem.totalBytesSystem = registry.Gauge("mem.maxHeapBytes", nil)
+	mem.numLiveObjects = registry.Gauge("mem.numLiveObjects", nil)
+	mem.objectsAllocated = NewMonotonicCounter(registry, "mem.objectsAllocated", nil)
+	mem.objectsFreed = NewMonotonicCounter(registry, "mem.objectsFreed", nil)
+	mem.gcPauseTime = registry.Timer("gc.pauseTime", nil)
+	mem.gcAge = registry.Gauge("gc.timeSinceLastGC", nil)
+	mem.gcCount = NewMonotonicCounter(registry, "gc.count", nil)
+	mem.forcedGcCount = NewMonotonicCounter(registry, "gc.forcedCount", nil)
+	mem.gcPercCpu = registry.Gauge("gc.cpuPercentage", nil)
 }
 
 // Collect memory stats

--- a/registry.go
+++ b/registry.go
@@ -77,7 +77,7 @@ func (r *Registry) SetLogger(logger Logger) {
 
 func (r *Registry) Start() {
 	if r.config == nil || r.config.Uri == "" {
-		r.log.Infof("Registry config has no uri.  Ingnoring Start request.")
+		r.log.Infof("Registry config has no uri. Ignoring Start request.")
 		return
 	}
 	if r.started {

--- a/runtime.go
+++ b/runtime.go
@@ -52,15 +52,9 @@ func goRuntimeStats(s *sysStatsCollector) {
 func CollectSysStats(registry *Registry) {
 	var s sysStatsCollector
 	s.registry = registry
-	fdTags := map[string]string{
-		"id": "fdstats",
-	}
-	goTags := map[string]string{
-		"id": "goRuntime",
-	}
-	s.maxOpen = registry.Gauge("fh.maxOpen", fdTags)
-	s.curOpen = registry.Gauge("fh.curOpen", fdTags)
-	s.numGoroutines = registry.Gauge("go.numGoroutines", goTags)
+	s.maxOpen = registry.Gauge("fh.allocated", nil)
+	s.curOpen = registry.Gauge("fh.max", nil)
+	s.numGoroutines = registry.Gauge("go.numGoroutines", nil)
 
 	ticker := time.NewTicker(30 * time.Second)
 	go func() {


### PR DESCRIPTION
Renames the file handle metrics to:

* `fh.allocated`

* `fh.max`

And removes the `id` tag from the metrics since it doesn't have a
function to distinguish/group the metrics