### PR TITLE
Deal with other statistics

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -116,8 +116,8 @@ func shouldSendMeasurement(measurement Measurement) bool {
 	if math.IsNaN(v) {
 		return false
 	}
-	s := measurement.id.tags["statistic"]
-	return s == "gauge" || v > 0
+	isGauge := opFromTags(measurement.id.tags) == maxOp
+	return isGauge || v > 0
 }
 
 func (r *Registry) getMeasurements() []Measurement {


### PR DESCRIPTION
Currently we were only considering statistic=gauge as a gauge, but in
the future we might add intervalCounters, percentile meters, or
longTaskTimers which make use of other statistic values. This changes
the logic of shouldSendMeasurement to take into account those values.