### PR TITLE
update for various linters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
 language: go
 go:
   - "1.10"
+install:
+  - go get -t ./...
+  - go get -u github.com/alecthomas/gometalinter
+  - gometalinter --install
+script:
+  - go test -v
+  - gometalinter -D golint ./...

--- a/atomicnum.go
+++ b/atomicnum.go
@@ -17,7 +17,6 @@ func addFloat64(addr *uint64, delta float64) {
 			break
 		}
 	}
-	return
 }
 
 func updateMax(addr *int64, v int64) {

--- a/id_test.go
+++ b/id_test.go
@@ -28,7 +28,6 @@ func TestId_mapKeySortsTags(t *testing.T) {
 		tags[k] = "v"
 	}
 	id := newId("foo", tags)
-	k := id.mapKey()
 
 	var buf bytes.Buffer
 	buf.WriteString("foo")
@@ -37,6 +36,7 @@ func TestId_mapKeySortsTags(t *testing.T) {
 		buf.WriteString(k)
 	}
 
+	k := id.mapKey()
 	if k != buf.String() {
 		t.Errorf("Expected %s, got %s", buf.String(), k)
 	}

--- a/memstats.go
+++ b/memstats.go
@@ -74,12 +74,9 @@ func CollectMemStats(registry *Registry) {
 	ticker := time.NewTicker(30 * time.Second)
 	go func() {
 		log := registry.log
-		for {
-			select {
-			case <-ticker.C:
-				log.Debugf("Collecting memory stats")
-				memStats(&mem)
-			}
+		for range ticker.C {
+			log.Debugf("Collecting memory stats")
+			memStats(&mem)
 		}
 	}()
 }

--- a/registry.go
+++ b/registry.go
@@ -87,7 +87,7 @@ func (r *Registry) Start() {
 
 	r.started = true
 	r.quit = make(chan struct{})
-	ticker := time.NewTicker(time.Duration(r.config.Frequency))
+	ticker := time.NewTicker(r.config.Frequency)
 	go func() {
 		for {
 			select {
@@ -278,7 +278,7 @@ func (r *Registry) TimerWithId(id *Id) *Timer {
 		return t
 	}
 
-	r.log.Errorf("Unable to register a timer with name=%s,tags=%v - a meter %v exists", id, t)
+	r.log.Errorf("Unable to register a timer with %v - a meter %v exists", id, t)
 
 	// throw in strict mode
 	return NewTimer(id)

--- a/registry_test.go
+++ b/registry_test.go
@@ -110,7 +110,7 @@ func getEntry(strings []string, payload []interface{}) (numConsumed int, entry p
 
 func payloadToEntries(t *testing.T, payload []interface{}) []payloadEntry {
 	numStrings := int(payload[0].(float64))
-	var strings = make([]string, numStrings, numStrings)
+	var strings = make([]string, numStrings)
 	for i := 1; i <= numStrings; i++ {
 		strings[i-1] = payload[i].(string)
 	}


### PR DESCRIPTION
adding gometalinter to the travis build for various lint checks.  I have disabled `golint` since none of the exported functions are documented, so it just produces a lot of noise.