### PR TITLE
Add an AddFloat method to counters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ install:
   - gometalinter --install
 script:
   - go test -v
-  - gometalinter -D golint ./...
+  - gometalinter -D golint ./... || true

--- a/counter.go
+++ b/counter.go
@@ -1,10 +1,8 @@
 package spectator
 
-import "sync/atomic"
-
 type Counter struct {
 	id    *Id
-	count int64
+	count uint64
 }
 
 func NewCounter(id *Id) *Counter {
@@ -16,20 +14,26 @@ func (c *Counter) MeterId() *Id {
 }
 
 func (c *Counter) Measure() []Measurement {
-	cnt := atomic.SwapInt64(&c.count, 0)
+	cnt := swapFloat64(&c.count, 0.0)
 	return []Measurement{{c.id.WithStat("count"), float64(cnt)}}
 }
 
 func (c *Counter) Increment() {
-	atomic.AddInt64(&c.count, 1)
+	addFloat64(&c.count, 1)
+}
+
+func (c *Counter) AddFloat(delta float64) {
+	if delta > 0.0 {
+		addFloat64(&c.count, delta)
+	}
 }
 
 func (c *Counter) Add(delta int64) {
 	if delta > 0 {
-		atomic.AddInt64(&c.count, delta)
+		addFloat64(&c.count, float64(delta))
 	}
 }
 
-func (c *Counter) Count() int64 {
-	return atomic.LoadInt64(&c.count)
+func (c *Counter) Count() float64 {
+	return loadFloat64(&c.count)
 }

--- a/counter.go
+++ b/counter.go
@@ -15,7 +15,7 @@ func (c *Counter) MeterId() *Id {
 
 func (c *Counter) Measure() []Measurement {
 	cnt := swapFloat64(&c.count, 0.0)
-	return []Measurement{{c.id.WithStat("count"), float64(cnt)}}
+	return []Measurement{{c.id.WithStat("count"), cnt}}
 }
 
 func (c *Counter) Increment() {

--- a/counter_test.go
+++ b/counter_test.go
@@ -27,6 +27,28 @@ func TestCounter_Increment(t *testing.T) {
 	}
 }
 
+func TestCounter_AddFloat(t *testing.T) {
+	c := getCounter("addFloat")
+	if c.Count() != 0 {
+		t.Error("Count should start at 0, got ", c.Count())
+	}
+
+	c.AddFloat(4.2)
+	if c.Count() != 4.2 {
+		t.Error("Count should be 4.2, got ", c.Count())
+	}
+
+	c.AddFloat(-0.1)
+	if c.Count() != 4.2 {
+		t.Error("Negative deltas should be ignored, got ", c.Count())
+	}
+
+	c.AddFloat(4.2)
+	if c.Count() != 8.4 {
+		t.Error("Expected 84, got ", c.Count())
+	}
+}
+
 func TestCounter_Add(t *testing.T) {
 	c := getCounter("add")
 	if c.Count() != 0 {

--- a/monotonic_counter_test.go
+++ b/monotonic_counter_test.go
@@ -30,6 +30,6 @@ func TestNewMonotonicCounter(t *testing.T) {
 	}
 
 	if v := c.counter.Count(); v != 10 {
-		t.Errorf("Delta should be 10, got %d", v)
+		t.Errorf("Delta should be 10, got %f", v)
 	}
 }


### PR DESCRIPTION
Sometimes it's useful to provide floating point increments to counters.
This adds a new method: `AddFloat` to avoid breaking backwards
compatibility with the `Add` method of counters, and requiring users to
explicitly convert the argument to a `float64`