### PR TITLE
Enable gometalinter in build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ install:
   - gometalinter --install
 script:
   - go test -v
-  - gometalinter -D golint ./... || true
+  - gometalinter -D golint ./... 

--- a/http_client_test.go
+++ b/http_client_test.go
@@ -50,7 +50,11 @@ func TestHttpClient_PostJsonOk(t *testing.T) {
 	log = registry.log
 	client := NewHttpClient(registry, 100*time.Millisecond)
 
-	statusCode := client.PostJson(config.Uri, []byte("42"))
+	statusCode, err := client.PostJson(config.Uri, []byte("42"))
+	if err != nil {
+		t.Error("Unexpected error", err)
+	}
+
 	if statusCode != 200 {
 		t.Error("Expected 200 response. Got", statusCode)
 	}
@@ -99,10 +103,10 @@ func TestHttpClient_PostJsonTimeout(t *testing.T) {
 	log = registry.log
 	client := NewHttpClient(registry, Timeout)
 
-	statusCode := client.PostJson(config.Uri, []byte("42"))
+	statusCode, err := client.PostJson(config.Uri, []byte("42"))
 	// 400 is our catch all for errors that are results of exceptions
-	if statusCode != 400 {
-		t.Error("Expected 400 response due to timeout. Got", statusCode)
+	if statusCode != 400 || err == nil {
+		t.Error("Expected 400 response due to timeout, with error set. Got", statusCode)
 	}
 
 	meters := registry.Meters()

--- a/id.go
+++ b/id.go
@@ -19,7 +19,11 @@ func (id *Id) mapKey() string {
 	}
 
 	var buf bytes.Buffer
-	buf.WriteString(id.name)
+	_, err := buf.WriteString(id.name)
+	const errKey = "ERR"
+	if err != nil {
+		return errKey
+	}
 	var keys []string
 	for k := range id.tags {
 		keys = append(keys, k)
@@ -28,10 +32,22 @@ func (id *Id) mapKey() string {
 
 	for _, k := range keys {
 		v := id.tags[k]
-		buf.WriteRune('|')
-		buf.WriteString(k)
-		buf.WriteRune('|')
-		buf.WriteString(v)
+		_, err = buf.WriteRune('|')
+		if err != nil {
+			return errKey
+		}
+		_, err = buf.WriteString(k)
+		if err != nil {
+			return errKey
+		}
+		_, err = buf.WriteRune('|')
+		if err != nil {
+			return errKey
+		}
+		_, err = buf.WriteString(v)
+		if err != nil {
+			return errKey
+		}
 	}
 	id.key = buf.String()
 	return id.key

--- a/runtime.go
+++ b/runtime.go
@@ -11,6 +11,7 @@ func getNumFiles(dir string) (n int, err error) {
 	var f *os.File
 	var entries []string
 
+	/* #nosec G304 */
 	f, err = os.Open(dir)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
Fixes the lint warnings with the exception of 'file path provided as taint
input' since that's the whole point of those functions