### PR TITLE
Batch measurements

### DIFF
--- a/registry_test.go
+++ b/registry_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func makeConfig(uri string) *Config {
-	return &Config{10 * time.Millisecond, 1 * time.Second, uri,
+	return &Config{10 * time.Millisecond, 1 * time.Second, uri, 10000,
 		map[string]string{
 			"nf.app":     "test",
 			"nf.cluster": "test-main",
@@ -32,6 +32,7 @@ func TestNewRegistryConfiguredBy(t *testing.T) {
 		5 * time.Second,
 		1 * time.Second,
 		"http://example.org/api/v4/update",
+		10000,
 		map[string]string{"nf.app": "app", "nf.account": "1234"},
 	}
 	if !reflect.DeepEqual(&expectedConfig, r.config) {

--- a/test_config.json
+++ b/test_config.json
@@ -2,6 +2,7 @@
   "frequency": 5,
   "timeout": 1,
   "uri": "http://example.org/api/v4/update",
+  "batch_size": 10000,
   "common_tags": {
     "nf.account": "1234",
     "nf.app": "app"


### PR DESCRIPTION
This introduces a new configuration setting to specify the maximum
number of measurements to send to our aggregator cluster. Some
applications were generating more than what we could process in a single
request, and we were getting errors like:

```
ERROR: 2018/10/04 21:39:41 Could not POST measurements: 500 <nil>
DEBUG: 2018/10/04 21:39:45 Got 42287 measurements
DEBUG: 2018/10/04 21:39:46 posting data to http://example.org/api/v4/update, payload is 9152185 bytes
DEBUG: 2018/10/04 21:39:46 request succeeded (500): {"type":"error","message":"EntityStreamSizeException: EntityStreamSizeException: actual entity size (None) exceeded content length limit (8388608 bytes)! You can configure this by setting `akka.http.[server|client].parsing.max-content-length` or calling `HttpEntity.withSizeLimit` before materializing the dataBytes stream."}<Paste>
```