### PR TITLE
Remove unused functions from fd_noop

### DIFF
--- a/fd_noop.go
+++ b/fd_noop.go
@@ -2,14 +2,6 @@
 
 package spectator
 
-func getNumFiles(dir string) (n int, err error) {
-	return 0, nil
-}
-
-func updateFdStats(s *sysStatsCollector, cur int, max uint64) {
-	// do nothing
-}
-
 func fdStats(s *sysStatsCollector) {
 	// do nothing
 }


### PR DESCRIPTION
`gometalinter` was complaining about them