### PR TITLE
Fix race condition in updateMax() that can cause an infinite loop.

### DIFF
--- a/atomicnum.go
+++ b/atomicnum.go
@@ -25,6 +25,7 @@ func updateMax(addr *int64, v int64) {
 		if atomic.CompareAndSwapInt64(addr, m, v) {
 			break
 		}
+		m = atomic.LoadInt64(addr)
 	}
 }
 

--- a/atomicnum_test.go
+++ b/atomicnum_test.go
@@ -1,0 +1,27 @@
+package spectator
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestUpdateMaxRace(t *testing.T) {
+	// The previous race condition in updateMax seemed to get caught at least 1/100 times with the below test, so we
+	// just run it multiple times to try and catch any race issue.
+	for testIteration := 0; testIteration < 100; testIteration++ {
+		m := int64(100)
+		wg := sync.WaitGroup{}
+		wg.Add(100)
+		for i := 0; i < 100; i++ {
+			go func(n int64) {
+				updateMax(&m, n)
+				wg.Done()
+			}(int64(100 + i))
+		}
+		wg.Wait()
+
+		if m != 199 {
+			t.Errorf("Got incorrect max value: %d", m)
+		}
+	}
+}


### PR DESCRIPTION
If the CompareAndSwapInt64 call fails then `m` has been updated. Since `m` never gets updated inside the loop, the `v > m` condition was always true but the `CompareAndSwapInt64` would always fail.