### PR TITLE
Add a creator function for Registry that allows a custom Logger

### DIFF
--- a/fd_linux.go
+++ b/fd_linux.go
@@ -38,12 +38,12 @@ func fdStats(s *sysStatsCollector) {
 	currentFdCount, err := getNumFiles("/proc/self/fd")
 	currentFdCount--
 	if err != nil {
-		s.registry.log.Errorf("Unable to get open files: %v", err)
+		s.registry.config.Log.Errorf("Unable to get open files: %v", err)
 	}
 
 	var rl syscall.Rlimit
 	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rl); err != nil {
-		s.registry.log.Errorf("Unable to get max open files: %v", err)
+		s.registry.config.Log.Errorf("Unable to get max open files: %v", err)
 	}
 	maxFdCount := rl.Cur
 	updateFdStats(s, currentFdCount, maxFdCount)

--- a/http_client.go
+++ b/http_client.go
@@ -64,7 +64,7 @@ func (h *HttpClient) createPayloadRequest(uri string, jsonBytes []byte) (*http.R
 
 func (h *HttpClient) PostJson(uri string, jsonBytes []byte) (statusCode int, err error) {
 	statusCode = 400
-	log := h.registry.log
+	log := h.registry.config.Log
 	var req *http.Request
 	req, err = h.createPayloadRequest(uri, jsonBytes)
 	if err != nil {

--- a/http_client_test.go
+++ b/http_client_test.go
@@ -47,7 +47,7 @@ func TestHttpClient_PostJsonOk(t *testing.T) {
 	config := makeConfig(serverUrl)
 	registry := NewRegistry(config)
 	registry.clock = clock
-	log = registry.log
+	log = registry.config.Log
 	client := NewHttpClient(registry, 100*time.Millisecond)
 
 	statusCode, err := client.PostJson(config.Uri, []byte("42"))
@@ -100,7 +100,7 @@ func TestHttpClient_PostJsonTimeout(t *testing.T) {
 	config := makeConfig(serverUrl)
 	registry := NewRegistry(config)
 	registry.clock = clock
-	log = registry.log
+	log = registry.config.Log
 	client := NewHttpClient(registry, Timeout)
 
 	statusCode, err := client.PostJson(config.Uri, []byte("42"))

--- a/memstats.go
+++ b/memstats.go
@@ -73,7 +73,7 @@ func CollectMemStats(registry *Registry) {
 
 	ticker := time.NewTicker(30 * time.Second)
 	go func() {
-		log := registry.log
+		log := registry.config.Log
 		for range ticker.C {
 			log.Debugf("Collecting memory stats")
 			memStats(&mem)

--- a/registry.go
+++ b/registry.go
@@ -58,6 +58,10 @@ func NewRegistry(config *Config) *Registry {
 	if config.IsEnabled == nil {
 		config.IsEnabled = func() bool { return true }
 	}
+	if config.Log == nil {
+		config.Log = defaultLogger()
+	}
+
 	r := &Registry{&SystemClock{}, config, map[string]Meter{}, false,
 		&sync.Mutex{}, nil, make(chan struct{})}
 	r.http = NewHttpClient(r, r.config.Timeout)

--- a/registry.go
+++ b/registry.go
@@ -55,11 +55,15 @@ func NewRegistryConfiguredBy(filePath string) (*Registry, error) {
 }
 
 func NewRegistry(config *Config) *Registry {
+	return NewRegistryWithLogger(config, defaultLogger())
+}
+
+func NewRegistryWithLogger(config *Config, logger Logger) *Registry {
 	if config.IsEnabled == nil {
 		config.IsEnabled = func() bool { return true }
 	}
 	r := &Registry{&SystemClock{}, config, map[string]Meter{}, false,
-		defaultLogger(), &sync.Mutex{}, nil, make(chan struct{})}
+		logger, &sync.Mutex{}, nil, make(chan struct{})}
 	r.http = NewHttpClient(r, r.config.Timeout)
 	return r
 }
@@ -101,7 +105,7 @@ func (r *Registry) Start() {
 			select {
 			case <-ticker.C:
 				// send measurements
-				r.log.Infof("Sending measurements")
+				r.log.Debugf("Sending measurements")
 				r.publish()
 			case <-r.quit:
 				ticker.Stop()

--- a/registry_test.go
+++ b/registry_test.go
@@ -20,6 +20,7 @@ func makeConfig(uri string) *Config {
 			"nf.region":  "us-west-1",
 		},
 		nil,
+		nil,
 	}
 }
 
@@ -37,6 +38,7 @@ func TestNewRegistryConfiguredBy(t *testing.T) {
 		"http://example.org/api/v4/update",
 		10000,
 		map[string]string{"nf.app": "app", "nf.account": "1234"},
+		defaultLogger(),
 		nil,
 	}
 	cfg := r.config

--- a/runtime.go
+++ b/runtime.go
@@ -26,7 +26,7 @@ func CollectSysStats(registry *Registry) {
 
 	ticker := time.NewTicker(30 * time.Second)
 	go func() {
-		log := registry.log
+		log := registry.config.Log
 		for range ticker.C {
 			log.Debugf("Collecting system stats")
 			fdStats(&s)


### PR DESCRIPTION
Add a creator function for `Registry` that allows a custom `Logger`

Also, lower the logging of `Sending measurements` statements to `DEBUG`.