### PR TITLE
Use ipc metric names

### DIFF
--- a/http_client_test.go
+++ b/http_client_test.go
@@ -73,7 +73,7 @@ func TestHttpClient_PostJsonOk(t *testing.T) {
 		"ipc.result":        "success",
 		"ipc.status":        "success",
 	}
-	expectedId := newId("ipc.client.call", expectedTags)
+	expectedId := NewId("ipc.client.call", expectedTags)
 	gotMeter := meters[0]
 	if expectedId.name != gotMeter.MeterId().name || !reflect.DeepEqual(expectedTags, gotMeter.MeterId().tags) {
 		log.Errorf("Unexpected meter registered. Expecting %v. Got %v", expectedId, gotMeter.MeterId())
@@ -125,7 +125,7 @@ func TestHttpClient_PostJsonTimeout(t *testing.T) {
 		"ipc.result":        "failure",
 		"ipc.status":        "timeout",
 	}
-	expectedId := newId("ipc.client.call", expectedTags)
+	expectedId := NewId("ipc.client.call", expectedTags)
 	gotMeter := meters[0]
 	if expectedId.name != gotMeter.MeterId().name || !reflect.DeepEqual(expectedTags, gotMeter.MeterId().tags) {
 		log.Errorf("Unexpected meter registered. Expecting %v. Got %v", expectedId, gotMeter.MeterId())

--- a/log_entry.go
+++ b/log_entry.go
@@ -1,0 +1,102 @@
+package spectator
+
+import (
+	"strconv"
+	"strings"
+	"time"
+)
+
+type LogEntry struct {
+	registry *Registry
+	start    int64
+	id       *Id
+}
+
+func (entry *LogEntry) SetStatusCode(code int) {
+	entry.id = entry.id.WithTag("http.status", strconv.Itoa(code))
+}
+
+func (entry *LogEntry) SetSuccess() {
+	extraTags := map[string]string{
+		"ipc.result": "success",
+		"ipc.status": "success",
+	}
+	entry.id = entry.id.WithTags(extraTags)
+}
+
+func (entry *LogEntry) SetError(err string) {
+	extraTags := map[string]string{
+		"ipc.result": "failure",
+		"ipc.status": err,
+	}
+	entry.id = entry.id.WithTags(extraTags)
+}
+
+func (entry *LogEntry) SetAttempt(attemptNumber int, final bool) {
+	extraTags := map[string]string{
+		"ipc.attempt":       attempt(attemptNumber),
+		"ipc.attempt.final": strconv.FormatBool(final),
+	}
+	entry.id = entry.id.WithTags(extraTags)
+}
+
+func (entry *LogEntry) Log() {
+	duration := entry.registry.Clock().Nanos() - entry.start
+	r := entry.registry
+	r.config.IpcTimerRecord(r, entry.id, time.Duration(duration))
+}
+
+func attempt(n int) string {
+	switch n {
+	case 0:
+		return "initial"
+	case 1:
+		return "second"
+	default:
+		return "third_up"
+	}
+}
+
+func pathFromUrl(url string) string {
+	if url == "" {
+		return "/"
+	}
+
+	protoEnd := strings.IndexByte(url, ':')
+	if protoEnd < 0 {
+		return url
+	}
+
+	protocolLen := len(url) - protoEnd
+	if protocolLen < 3 {
+		// does not have ://
+		return url
+	}
+
+	// find the path, skipping over protocol://
+	pathBegin := strings.IndexByte(url[protoEnd+3:], '/')
+	if pathBegin < 0 {
+		return "/"
+	}
+	pathBegin += protoEnd + 3
+
+	queryBegin := strings.IndexByte(url[pathBegin+1:], '?')
+	if queryBegin < 0 {
+		// no query component
+		return url[pathBegin:]
+	}
+	queryBegin += pathBegin + 1
+
+	return url[pathBegin:queryBegin]
+}
+
+func NewLogEntry(registry *Registry, method string, url string) *LogEntry {
+	tags := map[string]string{
+		"owner":        "spectator-go",
+		"ipc.endpoint": pathFromUrl(url),
+		"http.method":  method,
+		"http.status":  "-1",
+	}
+	return &LogEntry{registry, registry.Clock().Nanos(),
+		registry.NewId("ipc.client.call", tags)}
+}

--- a/log_entry_test.go
+++ b/log_entry_test.go
@@ -1,0 +1,185 @@
+package spectator
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func measurementsToMap(ms []Measurement) map[string]float64 {
+	var result = make(map[string]float64)
+	for _, m := range ms {
+		idStr := fmt.Sprintf("%s|%s", m.Id().Name(), m.Id().Tags()["statistic"])
+		p := m.Id().Tags()["percentile"]
+		if p != "" {
+			idStr += "|" + p
+		}
+		result[idStr] = m.Value()
+	}
+	return result
+}
+
+func TestLogEntry_Log(t *testing.T) {
+	clock := ManualClock{}
+	clock.SetFromDuration(0)
+	entry := getLogEntryWithClock(&Config{}, &clock)
+
+	entry.SetAttempt(0, true)
+	entry.SetStatusCode(200)
+	entry.SetSuccess()
+	clock.SetFromDuration(500 * time.Millisecond)
+	entry.Log()
+
+	ms := entry.registry.Measurements()
+	actual := measurementsToMap(ms)
+	expected := map[string]float64{
+		"ipc.client.call|totalTime":      0.5,
+		"ipc.client.call|totalOfSquares": 0.25,
+		"ipc.client.call|max":            0.5,
+		"ipc.client.call|count":          1,
+	}
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("Expected %v\nGot %v", expected, actual)
+	}
+}
+
+func TestLogEntry_LogCustom(t *testing.T) {
+	clock := ManualClock{}
+	clock.SetFromDuration(0)
+	config := Config{}
+	config.IpcTimerRecord = func(registry *Registry, id *Id, duration time.Duration) {
+		registry.TimerWithId(id).Record(duration)
+		registry.CounterWithId(id.WithStat("percentile").WithTag("percentile", "T007D")).Increment()
+	}
+	entry := getLogEntryWithClock(&config, &clock)
+
+	entry.SetAttempt(0, true)
+	entry.SetStatusCode(200)
+	entry.SetSuccess()
+	clock.SetFromDuration(500 * time.Millisecond)
+	entry.Log()
+
+	ms := entry.registry.Measurements()
+	actual := measurementsToMap(ms)
+	expected := map[string]float64{
+		"ipc.client.call|totalTime":        0.5,
+		"ipc.client.call|totalOfSquares":   0.25,
+		"ipc.client.call|max":              0.5,
+		"ipc.client.call|count":            1,
+		"ipc.client.call|percentile|T007D": 1,
+	}
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("Expected %v\nGot %v", expected, actual)
+	}
+}
+
+func TestLogEntry_SetSuccess(t *testing.T) {
+	entry := getLogEntry()
+	entry.SetSuccess()
+	if v := entry.id.Tags()["ipc.result"]; v != "success" {
+		t.Error("Expected success, got", v)
+	}
+
+	if v := entry.id.Tags()["ipc.status"]; v != "success" {
+		t.Error("Expected success, got", v)
+	}
+}
+
+func TestLogEntry_SetError(t *testing.T) {
+	entry := getLogEntry()
+	entry.SetError("some-err")
+	if v := entry.id.Tags()["ipc.result"]; v != "failure" {
+		t.Error("Expected failure, got", v)
+	}
+
+	if v := entry.id.Tags()["ipc.status"]; v != "some-err" {
+		t.Error("Expected some-err, got", v)
+	}
+}
+
+func TestLogEntry_SetStatusCode(t *testing.T) {
+	entry := getLogEntry()
+	entry.SetStatusCode(404)
+	if c := entry.id.Tags()["http.status"]; c != "404" {
+		t.Error("Expected 404, got", c)
+	}
+}
+
+func TestLogEntry_SetAttempt(t *testing.T) {
+	entry := getLogEntry()
+	entry.SetAttempt(0, true)
+	if attempt := entry.id.Tags()["ipc.attempt"]; attempt != "initial" {
+		t.Error("Expected initial, got", attempt)
+	}
+	if final := entry.id.Tags()["ipc.attempt.final"]; final != "true" {
+		t.Error("Expected true, got", final)
+	}
+	entry.SetAttempt(1, false)
+	if attempt := entry.id.Tags()["ipc.attempt"]; attempt != "second" {
+		t.Error("Expected second, got", attempt)
+	}
+	if final := entry.id.Tags()["ipc.attempt.final"]; final != "false" {
+		t.Error("Expected false, got", final)
+	}
+	entry.SetAttempt(10, true)
+	if attempt := entry.id.Tags()["ipc.attempt"]; attempt != "third_up" {
+		t.Error("Expected third_up, got", attempt)
+	}
+	if final := entry.id.Tags()["ipc.attempt.final"]; final != "true" {
+		t.Error("Expected true, got", final)
+	}
+}
+
+func getLogEntry() *LogEntry {
+	return getLogEntryWithClock(&Config{}, &SystemClock{})
+}
+
+func getLogEntryWithClock(config *Config, clock Clock) *LogEntry {
+	registry := NewRegistryWithClock(config, clock)
+	entry := NewLogEntry(registry, "POST", "/api/v4/update")
+	return entry
+}
+
+func TestPathFromUrl_Empty(t *testing.T) {
+	if p := pathFromUrl(""); p != "/" {
+		t.Error("Empty Url should get / - Got", p)
+	}
+}
+
+func TestPathFromUrl_OnlyPath(t *testing.T) {
+	if p := pathFromUrl("/fo"); p != "/fo" {
+		t.Error("Just a path should get the same value back - Got", p)
+	}
+}
+
+func TestPathFromUrl_NoSlashSlash(t *testing.T) {
+	if p := pathFromUrl("foo:/"); p != "foo:/" {
+		t.Error("No protocol:// - Got", p)
+	}
+}
+
+func TestPathFromUrl_OnlyHost(t *testing.T) {
+	if p := pathFromUrl("ftp://foo.example.com"); p != "/" {
+		t.Error("Only host - Got", p)
+	}
+}
+
+func TestPathFromUrl_NoQueryString(t *testing.T) {
+	p := pathFromUrl("ftp://foo.example.com/api/v4/update")
+	if p != "/api/v4/update" {
+		t.Error("No query string - Got", p)
+	}
+
+	p = pathFromUrl("ftp://foo.example.com/api/v4/update?")
+	if p != "/api/v4/update" {
+		t.Error("No query string - Got", p)
+	}
+}
+
+func TestPathFromUrl_QueryString(t *testing.T) {
+	p := pathFromUrl("ftp://foo.example.com/api/v4/update?foo=bar&baz=/foo")
+	if p != "/api/v4/update" {
+		t.Error("Url with query string - Got", p)
+	}
+}

--- a/memstats.go
+++ b/memstats.go
@@ -73,7 +73,7 @@ func CollectMemStats(registry *Registry) {
 
 	ticker := time.NewTicker(30 * time.Second)
 	go func() {
-		log := registry.config.Log
+		log := registry.GetLogger()
 		for range ticker.C {
 			log.Debugf("Collecting memory stats")
 			memStats(&mem)

--- a/memstats_test.go
+++ b/memstats_test.go
@@ -7,9 +7,8 @@ import (
 )
 
 func TestUpdateMemStats(t *testing.T) {
-	registry := NewRegistry(makeConfig(""))
 	var clock ManualClock
-	registry.clock = &clock
+	registry := NewRegistryWithClock(makeConfig(""), &clock)
 	var mem memStatsCollector
 
 	initializeMemStatsCollector(registry, &mem)

--- a/registry_test.go
+++ b/registry_test.go
@@ -21,6 +21,7 @@ func makeConfig(uri string) *Config {
 		},
 		nil,
 		nil,
+		nil,
 	}
 }
 
@@ -40,9 +41,11 @@ func TestNewRegistryConfiguredBy(t *testing.T) {
 		map[string]string{"nf.app": "app", "nf.account": "1234"},
 		defaultLogger(),
 		nil,
+		nil,
 	}
 	cfg := r.config
 	cfg.IsEnabled = nil
+	cfg.IpcTimerRecord = nil
 	if !reflect.DeepEqual(&expectedConfig, cfg) {
 		t.Errorf("Expected config %v, got %v", expectedConfig, cfg)
 	}
@@ -87,9 +90,8 @@ func TestRegistry_Timer(t *testing.T) {
 }
 
 func TestRegistry_Start(t *testing.T) {
-	r := NewRegistry(config)
 	clock := &ManualClock{1}
-	r.clock = clock
+	r := NewRegistryWithClock(config, clock)
 	r.Counter("foo", nil).Increment()
 	r.Start()
 	time.Sleep(30 * time.Millisecond)


### PR DESCRIPTION
Switch from the old spectator names, to the new IPC metric names:

https://netflix.github.io/spectator/en/latest/ext/ipc/

This adds a hook to the config to allow the user to specify which timer
record implementation to use. Usually this is done with a
PercentileTimer but since that is part of the histogram package we
cannot easily use it without creating a circular dependency. The default
is a basic timer.