### PR TITLE
Retry 503s and consider matrix params/fragments

### DIFF
--- a/log_entry.go
+++ b/log_entry.go
@@ -80,14 +80,16 @@ func pathFromUrl(url string) string {
 	}
 	pathBegin += protoEnd + 3
 
-	queryBegin := strings.IndexByte(url[pathBegin+1:], '?')
-	if queryBegin < 0 {
+	// find the first character that ends the path, could be beginning of query params, matrix params, or
+	// url fragment
+	pathEnd := strings.IndexAny(url[pathBegin+1:], "?#;")
+	if pathEnd < 0 {
 		// no query component
 		return url[pathBegin:]
 	}
-	queryBegin += pathBegin + 1
+	pathEnd += pathBegin + 1
 
-	return url[pathBegin:queryBegin]
+	return url[pathBegin:pathEnd]
 }
 
 func NewLogEntry(registry *Registry, method string, url string) *LogEntry {

--- a/log_entry_test.go
+++ b/log_entry_test.go
@@ -183,3 +183,10 @@ func TestPathFromUrl_QueryString(t *testing.T) {
 		t.Error("Url with query string - Got", p)
 	}
 }
+
+func TestPathFromUrl_MatrixFrag(t *testing.T) {
+	p := pathFromUrl("ftp://foo.example.com/api/v4/update;foo=bar#someAnchor")
+	if p != "/api/v4/update" {
+		t.Error("Url with query string - Got", p)
+	}
+}


### PR DESCRIPTION
Retry 503 errors, adding some backoff time.

Use the the path until the first query param, matrix param, or url
fragment as our ipc.endpoint