### PR TITLE
Deal with monotonic counters that start at zero

### DIFF
--- a/memstats_test.go
+++ b/memstats_test.go
@@ -28,7 +28,7 @@ func TestUpdateMemStats(t *testing.T) {
 	updateMemStats(&mem, &memStats)
 
 	ms := registry.Meters()
-	if len(ms) != 6 {
+	if len(ms) != 11 {
 		t.Error("Expected 6 meters registered, got", len(ms))
 	}
 

--- a/monotonic_counter.go
+++ b/monotonic_counter.go
@@ -18,11 +18,10 @@ func NewMonotonicCounterWithId(registry *Registry, id *Id) *MonotonicCounter {
 }
 
 func (c *MonotonicCounter) Set(amount int64) {
-	prev := atomic.LoadInt64(&c.value)
-	if prev > 0 {
-		if c.counter == nil {
-			c.counter = c.registry.CounterWithId(c.id)
-		}
+	if c.counter == nil {
+		c.counter = c.registry.CounterWithId(c.id)
+	} else {
+		prev := atomic.LoadInt64(&c.value)
 		delta := amount - prev
 		if delta >= 0 {
 			c.counter.Add(delta)

--- a/monotonic_counter_test.go
+++ b/monotonic_counter_test.go
@@ -10,17 +10,9 @@ func TestNewMonotonicCounter(t *testing.T) {
 		t.Errorf("Counters should be initialized to 0, got %d", v)
 	}
 
-	if c.counter != nil {
-		t.Errorf("Underlying counter should be nil until we get a delta")
-	}
-
 	c.Set(42)
 	if v := c.Count(); v != 42 {
 		t.Errorf("Expected 42, got %d", v)
-	}
-
-	if c.counter != nil {
-		t.Errorf("Underlying counter should be nil until we get a delta")
 	}
 
 	// now we have a delta
@@ -31,5 +23,24 @@ func TestNewMonotonicCounter(t *testing.T) {
 
 	if v := c.counter.Count(); v != 10 {
 		t.Errorf("Delta should be 10, got %f", v)
+	}
+}
+
+func TestMonotonicCounterStartingAt0(t *testing.T) {
+	r := NewRegistry(makeConfig("http://example.org"))
+	c := NewMonotonicCounter(r, "mono", nil)
+
+	c.Set(0)
+	if c.counter == nil {
+		t.Fatalf("Underlying counter should not be nil")
+	}
+
+	if c.counter.Count() != 0.0 {
+		t.Errorf("Count should be 0, got %f", c.counter.Count())
+	}
+
+	c.Set(1)
+	if c.counter.Count() != 1.0 {
+		t.Errorf("Count should be 1, got %f", c.counter.Count())
 	}
 }


### PR DESCRIPTION
®Previously we would need two non-zero samples before emitting a delta.
Now we honor a `Set(0)` and will emit a delta the first time we see
activity for that counter.