### PR TITLE
Track measurements sent/dropped

### DIFF
--- a/counter.go
+++ b/counter.go
@@ -15,7 +15,11 @@ func (c *Counter) MeterId() *Id {
 
 func (c *Counter) Measure() []Measurement {
 	cnt := swapFloat64(&c.count, 0.0)
-	return []Measurement{{c.id.WithDefaultStat("count"), cnt}}
+	if cnt > 0 {
+		return []Measurement{{c.id.WithDefaultStat("count"), cnt}}
+	} else {
+		return []Measurement{}
+	}
 }
 
 func (c *Counter) Increment() {

--- a/http_client.go
+++ b/http_client.go
@@ -62,9 +62,14 @@ func (h *HttpClient) createPayloadRequest(uri string, jsonBytes []byte) (*http.R
 
 const maxAttempts = 3
 
-func (h *HttpClient) doHttpPost(uri string, jsonBytes []byte, attemptNumber int) (statusCode int, err error) {
+type httpResponse struct {
+	status int
+	body   []byte
+}
+
+func (h *HttpClient) doHttpPost(uri string, jsonBytes []byte, attemptNumber int) (response httpResponse, err error) {
 	var willRetry bool
-	statusCode = 400
+	response.status = -1
 	log := h.registry.GetLogger()
 	var req *http.Request
 	req, err = h.createPayloadRequest(uri, jsonBytes)
@@ -91,29 +96,33 @@ func (h *HttpClient) doHttpPost(uri string, jsonBytes []byte, attemptNumber int)
 		}
 		entry.SetError(status)
 		willRetry = false
-		log.Errorf("Unable to POST to %s: %v", uri, err)
+		if timeout, ok := err.(*url.Error); ok && timeout.Timeout() {
+			log.Infof("Timed out attempting to POST to %s", uri)
+		} else {
+			log.Infof("Unable to POST to %s: %v", uri, err)
+		}
 	} else {
 		defer func() {
 			if err = resp.Body.Close(); err != nil {
 				log.Errorf("Unable to close body: %v", err)
 			}
 		}()
-		statusCode = resp.StatusCode
+		response.status = resp.StatusCode
 		entry.SetStatusCode(resp.StatusCode)
 		var body []byte
-		body, err = ioutil.ReadAll(resp.Body)
+		response.body, err = ioutil.ReadAll(resp.Body)
 		if err != nil {
 			log.Errorf("Unable to read response body: %v", err)
 			return
 		}
 		log.Debugf("response HTTP %d: %s", resp.StatusCode, body)
-		if statusCode == 200 {
+		if response.status >= 200 && response.status < 300 {
 			entry.SetSuccess()
 		} else {
 			entry.SetError("http-error")
 		}
 		// only retry 503s for now
-		willRetry = statusCode == 503
+		willRetry = response.status == 503
 	}
 
 	final := !(willRetry && (attemptNumber+1) < maxAttempts)
@@ -122,10 +131,10 @@ func (h *HttpClient) doHttpPost(uri string, jsonBytes []byte, attemptNumber int)
 	return
 }
 
-func (h *HttpClient) PostJson(uri string, jsonBytes []byte) (statusCode int, err error) {
+func (h *HttpClient) postJson(uri string, jsonBytes []byte) (response httpResponse, err error) {
 	for attemptNumber := 0; attemptNumber < maxAttempts; attemptNumber += 1 {
-		statusCode, err = h.doHttpPost(uri, jsonBytes, attemptNumber)
-		willRetry := statusCode == 503 && err == nil
+		response, err = h.doHttpPost(uri, jsonBytes, attemptNumber)
+		willRetry := err == nil && response.status == 503
 		if !willRetry {
 			break
 		}

--- a/memstats_test.go
+++ b/memstats_test.go
@@ -27,7 +27,7 @@ func TestUpdateMemStats(t *testing.T) {
 	memStats.PauseTotalNs = uint64(5 * time.Millisecond)
 	updateMemStats(&mem, &memStats)
 
-	ms := registry.Meters()
+	ms := myMeters(registry)
 	if len(ms) != 11 {
 		t.Error("Expected 11 meters registered, got", len(ms))
 	}
@@ -46,11 +46,17 @@ func TestUpdateMemStats(t *testing.T) {
 		} else {
 			expected := expectedValues[name]
 			measures := m.Measure()
-			if len(measures) != 1 {
-				t.Errorf("Expected one value from %v: got %d", m.MeterId(), len(measures))
-			}
-			if v := measures[0].value; v != expected {
-				t.Errorf("%v: expected %f. got %f", m.MeterId(), expected, v)
+			if expected > 0 {
+				if len(measures) != 1 {
+					t.Fatalf("Expected one value from %v: got %d", m.MeterId(), len(measures))
+				}
+				if v := measures[0].value; v != expected {
+					t.Errorf("%v: expected %f. got %f", m.MeterId(), expected, v)
+				}
+			} else {
+				if len(measures) != 0 {
+					t.Errorf("Unexpected measurements from %v: got %d measurements", m.MeterId(), len(measures))
+				}
 			}
 		}
 	}
@@ -89,11 +95,15 @@ func TestUpdateMemStats(t *testing.T) {
 		} else {
 			expected := expectedValues[name]
 			measures := m.Measure()
-			if len(measures) != 1 {
-				t.Errorf("Expected one value from %v: got %d", m.MeterId(), len(measures))
-			}
-			if v := measures[0].value; v != expected {
-				t.Errorf("%v: expected %f. got %f", m.MeterId(), expected, v)
+			if expected > 0 {
+				if len(measures) != 1 {
+					t.Errorf("Expected one value from %v: got %d", m.MeterId(), len(measures))
+				}
+				if v := measures[0].value; v != expected {
+					t.Errorf("%v: expected %f. got %f", m.MeterId(), expected, v)
+				}
+			} else if len(measures) != 0 {
+				t.Errorf("Unexpected measurements from %v: got %d measurements", m.MeterId(), len(measures))
 			}
 		}
 	}

--- a/registry.go
+++ b/registry.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 )
@@ -28,13 +29,17 @@ type Config struct {
 }
 
 type Registry struct {
-	clock   Clock
-	config  *Config
-	meters  map[string]Meter
-	started bool
-	mutex   *sync.Mutex
-	http    *HttpClient
-	quit    chan struct{}
+	clock          Clock
+	config         *Config
+	meters         map[string]Meter
+	started        bool
+	mutex          *sync.Mutex
+	http           *HttpClient
+	sentMetrics    *Counter
+	invalidMetrics *Counter
+	droppedHttp    *Counter
+	droppedOther   *Counter
+	quit           chan struct{}
 }
 
 func NewRegistryConfiguredBy(filePath string) (*Registry, error) {
@@ -70,8 +75,18 @@ func NewRegistry(config *Config) *Registry {
 	}
 
 	r := &Registry{&SystemClock{}, config, map[string]Meter{}, false,
-		&sync.Mutex{}, nil, make(chan struct{})}
+		&sync.Mutex{}, nil, nil, nil, nil, nil,
+		make(chan struct{})}
 	r.http = NewHttpClient(r, r.config.Timeout)
+	r.sentMetrics = r.Counter("spectator.measurements",
+		map[string]string{"id": "sent"})
+	r.invalidMetrics = r.Counter("spectator.measurements",
+		map[string]string{"id": "dropped", "error": "validation"})
+	r.droppedHttp = r.Counter("spectator.measurements",
+		map[string]string{"id": "dropped", "error": "http-error"})
+	r.droppedOther = r.Counter("spectator.measurements",
+		map[string]string{"id": "dropped", "error": "other"})
+
 	return r
 }
 
@@ -168,16 +183,66 @@ func (r *Registry) Measurements() []Measurement {
 	return measurements
 }
 
+type atlasMessage struct {
+	Type       string   `json:"type"`
+	ErrorCount int      `json:"errorCount"`
+	Message    []string `json:"message"`
+}
+
+func getUnique(messages []string) string {
+	uniq := map[string]struct{}{}
+	for _, msg := range messages {
+		uniq[msg] = struct{}{}
+	}
+	keys := make([]string, 0, len(uniq))
+	for key := range uniq {
+		keys = append(keys, key)
+	}
+	return strings.Join(keys, "; ")
+}
+
 func (r *Registry) sendBatch(measurements []Measurement) {
+	numMeasurements := int64(len(measurements))
 	r.config.Log.Debugf("Sending %d measurements to %s", len(measurements), r.config.Uri)
 	jsonBytes, err := r.measurementsToJson(measurements)
 	if err != nil {
+		r.droppedOther.Add(numMeasurements)
 		r.config.Log.Errorf("Unable to convert measurements to json: %v", err)
 	} else {
-		var status int
-		status, err = r.http.PostJson(r.config.Uri, jsonBytes)
-		if status != 200 || err != nil {
-			r.config.Log.Errorf("Could not POST measurements: HTTP %d %v", status, err)
+		var resp httpResponse
+		resp, err = r.http.postJson(r.config.Uri, jsonBytes)
+		if err != nil {
+			r.droppedHttp.Add(numMeasurements)
+		} else {
+			sent := int64(0)
+			dropped := int64(0)
+			if resp.status == 200 {
+				sent = numMeasurements
+			} else if resp.status < 500 {
+				var atlasResponse atlasMessage
+				err = json.Unmarshal(resp.body, atlasResponse)
+				if err != nil {
+					r.config.Log.Errorf("%d measurement(s) dropped. Http status: %d", numMeasurements, resp.status)
+					r.droppedOther.Add(numMeasurements)
+				} else {
+					dropped = int64(atlasResponse.ErrorCount)
+					sent = numMeasurements - dropped
+					// get the unique error messages
+					var errorMsg string
+					if len(atlasResponse.Message) > 0 {
+						errorMsg = getUnique(atlasResponse.Message)
+					} else {
+						errorMsg = "unknown cause"
+					}
+					r.config.Log.Infof("%d measurement(s) dropped due to validation errors: %s",
+						dropped, errorMsg)
+				}
+			} else {
+				// 5xx error from server, note that sent and dropped are 0
+				r.droppedHttp.Add(numMeasurements)
+			}
+			r.invalidMetrics.Add(dropped)
+			r.sentMetrics.Add(sent)
 		}
 	}
 }
@@ -203,36 +268,36 @@ func (r *Registry) publish() {
 }
 
 func (r *Registry) buildStringTable(payload *[]interface{}, measurements []Measurement) map[string]int {
-	var strings = make(map[string]int)
+	var strTable = make(map[string]int)
 	commonTags := r.config.CommonTags
 	for k, v := range commonTags {
-		strings[k] = 0
-		strings[v] = 0
+		strTable[k] = 0
+		strTable[v] = 0
 	}
 
-	strings["name"] = 0
+	strTable["name"] = 0
 	for _, measure := range measurements {
-		strings[measure.id.name] = 0
+		strTable[measure.id.name] = 0
 		for k, v := range measure.id.tags {
-			strings[k] = 0
-			strings[v] = 0
+			strTable[k] = 0
+			strTable[v] = 0
 		}
 	}
-	sortedStrings := make([]string, 0, len(strings))
-	for s := range strings {
+	sortedStrings := make([]string, 0, len(strTable))
+	for s := range strTable {
 		sortedStrings = append(sortedStrings, s)
 	}
 	sort.Strings(sortedStrings)
 	for i, s := range sortedStrings {
-		strings[s] = i
+		strTable[s] = i
 	}
-	*payload = append(*payload, len(strings))
+	*payload = append(*payload, len(strTable))
 	// can't append the strings in one call since we can't convert []string to []interface{}
 	for _, s := range sortedStrings {
 		*payload = append(*payload, s)
 	}
 
-	return strings
+	return strTable
 }
 
 const (
@@ -269,9 +334,9 @@ func (r *Registry) appendMeasurement(payload *[]interface{}, strings map[string]
 
 func (r *Registry) measurementsToJson(measurements []Measurement) ([]byte, error) {
 	var payload []interface{}
-	strings := r.buildStringTable(&payload, measurements)
+	stringTable := r.buildStringTable(&payload, measurements)
 	for _, m := range measurements {
-		r.appendMeasurement(&payload, strings, m)
+		r.appendMeasurement(&payload, stringTable, m)
 	}
 
 	return json.Marshal(payload)


### PR DESCRIPTION
Improve error messages around invalid metrics and time outs, and keep
track of the number of measurements sent/dropped due to various causes,
like validation or http errors.