### PR TITLE
Track measurements sent/dropped

### DIFF
--- a/counter.go
+++ b/counter.go
@@ -15,7 +15,11 @@ func (c *Counter) MeterId() *Id {
 
 func (c *Counter) Measure() []Measurement {
 	cnt := swapFloat64(&c.count, 0.0)
-	return []Measurement{{c.id.WithDefaultStat("count"), cnt}}
+	if cnt > 0 {
+		return []Measurement{{c.id.WithDefaultStat("count"), cnt}}
+	} else {
+		return []Measurement{}
+	}
 }
 
 func (c *Counter) Increment() {

--- a/http_client_test.go
+++ b/http_client_test.go
@@ -121,10 +121,9 @@ func TestHttpClient_PostJsonTimeout(t *testing.T) {
 	log = registry.GetLogger()
 	client := NewHttpClient(registry, Timeout)
 
-	resp, err := client.PostJson(config.Uri, []byte("42"))
-	// 400 is our catch all for errors that are results of exceptions
-	if err != nil && (&resp != nil && resp.status != -1) {
-		t.Error("Expected -1 response due to timeout, with error set. Got", resp)
+	_, err := client.PostJson(config.Uri, []byte("42"))
+	if err == nil {
+		t.Fatal("Expected an error due to timeout")
 	}
 
 	meters := myMeters(registry)

--- a/http_client_test.go
+++ b/http_client_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 )
@@ -22,6 +23,16 @@ var errJson = map[string]string{
 
 var okMsg, _ = json.Marshal(ok)
 var errMsg, _ = json.Marshal(errJson)
+
+func myMeters(registry *Registry) []Meter {
+	var myMeters []Meter
+	for _, meter := range registry.Meters() {
+		if !strings.HasPrefix(meter.MeterId().name, "spectator.") {
+			myMeters = append(myMeters, meter)
+		}
+	}
+	return myMeters
+}
 
 func TestHttpClient_PostJsonOk(t *testing.T) {
 	var log Logger
@@ -55,16 +66,16 @@ func TestHttpClient_PostJsonOk(t *testing.T) {
 	log = registry.GetLogger()
 	client := NewHttpClient(registry, 100*time.Millisecond)
 
-	statusCode, err := client.PostJson(config.Uri, []byte("42"))
+	resp, err := client.PostJson(config.Uri, []byte("42"))
 	if err != nil {
 		t.Error("Unexpected error", err)
 	}
 
-	if statusCode != 200 {
-		t.Error("Expected 200 response. Got", statusCode)
+	if resp.status != 200 {
+		t.Error("Expected 200 response. Got", resp.status)
 	}
 
-	meters := registry.Meters()
+	meters := myMeters(registry)
 	if len(meters) != 1 {
 		t.Fatal("Expected 1 meter, got", len(meters))
 	}
@@ -110,13 +121,13 @@ func TestHttpClient_PostJsonTimeout(t *testing.T) {
 	log = registry.GetLogger()
 	client := NewHttpClient(registry, Timeout)
 
-	statusCode, err := client.PostJson(config.Uri, []byte("42"))
+	resp, err := client.PostJson(config.Uri, []byte("42"))
 	// 400 is our catch all for errors that are results of exceptions
-	if statusCode != 400 || err == nil {
-		t.Error("Expected 400 response due to timeout, with error set. Got", statusCode)
+	if err != nil && (&resp != nil && resp.status != -1) {
+		t.Error("Expected -1 response due to timeout, with error set. Got", resp)
 	}
 
-	meters := registry.Meters()
+	meters := myMeters(registry)
 	if len(meters) != 1 {
 		t.Fatal("Expected 1 meter, got", len(meters))
 	}
@@ -173,16 +184,16 @@ func TestHttpClient_PostJson503(t *testing.T) {
 	registry := NewRegistryWithClock(config, clock)
 	client := NewHttpClient(registry, 100*time.Millisecond)
 
-	statusCode, err := client.PostJson(config.Uri, []byte("42"))
+	resp, err := client.PostJson(config.Uri, []byte("42"))
 	if err != nil {
-		t.Error("Unexpected error", err)
+		t.Fatal("Unexpected error", err)
 	}
 
-	if statusCode != 503 {
-		t.Error("Expected 503 response. Got", statusCode)
+	if resp.status != 503 {
+		t.Error("Expected 503 response. Got", resp.status)
 	}
 
-	meters := registry.Meters()
+	meters := myMeters(registry)
 	sort.Slice(meters, func(i, j int) bool {
 		return meters[i].MeterId().Tags()["ipc.attempt"] < meters[j].MeterId().Tags()["ipc.attempt"]
 	})

--- a/log_entry_test.go
+++ b/log_entry_test.go
@@ -15,6 +15,10 @@ func measurementsToMap(ms []Measurement) map[string]float64 {
 		if p != "" {
 			idStr += "|" + p
 		}
+		id := m.id.tags["id"]
+		if id != "" {
+			idStr += "|" + id
+		}
 		result[idStr] = m.Value()
 	}
 	return result

--- a/memstats_test.go
+++ b/memstats_test.go
@@ -27,7 +27,7 @@ func TestUpdateMemStats(t *testing.T) {
 	memStats.PauseTotalNs = uint64(5 * time.Millisecond)
 	updateMemStats(&mem, &memStats)
 
-	ms := registry.Meters()
+	ms := myMeters(registry)
 	if len(ms) != 11 {
 		t.Error("Expected 11 meters registered, got", len(ms))
 	}
@@ -46,11 +46,17 @@ func TestUpdateMemStats(t *testing.T) {
 		} else {
 			expected := expectedValues[name]
 			measures := m.Measure()
-			if len(measures) != 1 {
-				t.Errorf("Expected one value from %v: got %d", m.MeterId(), len(measures))
-			}
-			if v := measures[0].value; v != expected {
-				t.Errorf("%v: expected %f. got %f", m.MeterId(), expected, v)
+			if expected > 0 {
+				if len(measures) != 1 {
+					t.Fatalf("Expected one value from %v: got %d", m.MeterId(), len(measures))
+				}
+				if v := measures[0].value; v != expected {
+					t.Errorf("%v: expected %f. got %f", m.MeterId(), expected, v)
+				}
+			} else {
+				if len(measures) != 0 {
+					t.Errorf("Unexpected measurements from %v: got %d measurements", m.MeterId(), len(measures))
+				}
 			}
 		}
 	}
@@ -89,11 +95,15 @@ func TestUpdateMemStats(t *testing.T) {
 		} else {
 			expected := expectedValues[name]
 			measures := m.Measure()
-			if len(measures) != 1 {
-				t.Errorf("Expected one value from %v: got %d", m.MeterId(), len(measures))
-			}
-			if v := measures[0].value; v != expected {
-				t.Errorf("%v: expected %f. got %f", m.MeterId(), expected, v)
+			if expected > 0 {
+				if len(measures) != 1 {
+					t.Errorf("Expected one value from %v: got %d", m.MeterId(), len(measures))
+				}
+				if v := measures[0].value; v != expected {
+					t.Errorf("%v: expected %f. got %f", m.MeterId(), expected, v)
+				}
+			} else if len(measures) != 0 {
+				t.Errorf("Unexpected measurements from %v: got %d measurements", m.MeterId(), len(measures))
 			}
 		}
 	}


### PR DESCRIPTION
Improve error messages around invalid metrics and time outs, and keep
track of the number of measurements sent/dropped due to various causes,
like validation or http errors.