### PR TITLE
Reuse http client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - "1.12"
+  - "1.14"
 install:
   - go get -t ./...
   - curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.18.0

--- a/http_client.go
+++ b/http_client.go
@@ -17,12 +17,11 @@ import (
 
 type HttpClient struct {
 	registry *Registry
-	timeout  time.Duration
 	client   *http.Client
 }
 
 func NewHttpClient(registry *Registry, timeout time.Duration) *HttpClient {
-	return &HttpClient{registry, timeout, newSingleHostClient()}
+	return &HttpClient{registry, newSingleHostClient(timeout)}
 }
 
 func userFriendlyErr(errStr string) string {
@@ -146,23 +145,24 @@ func (h *HttpClient) PostJson(uri string, jsonBytes []byte) (response HttpRespon
 	}
 	return
 }
-func newSingleHostClient() *http.Client {
+func newSingleHostClient(timeout time.Duration) *http.Client {
 	return &http.Client{
+		Timeout: timeout,
 		Transport: &keepAliveTransport{wrapped: &http.Transport{
 			Proxy: http.ProxyFromEnvironment,
 			DialContext: (&net.Dialer{
-				Timeout:   10 * time.Second,
-				KeepAlive: 90 * time.Second,
+				Timeout:   5 * time.Second,
+				KeepAlive: 30 * time.Second,
 				DualStack: true,
 			}).DialContext,
 			ForceAttemptHTTP2:     true,
-			MaxIdleConns:          10,
-			MaxIdleConnsPerHost:   10,
-			MaxConnsPerHost:       30,
-			IdleConnTimeout:       90 * time.Second,
-			TLSHandshakeTimeout:   10 * time.Second,
+			MaxIdleConns:          50,
+			MaxIdleConnsPerHost:   50,
+			MaxConnsPerHost:       100,
+			IdleConnTimeout:       30 * time.Second,
+			TLSHandshakeTimeout:   2 * time.Second,
 			ExpectContinueTimeout: 1 * time.Second,
-			DisableKeepAlives:     true,
+			// DisableKeepAlives:     true,
 		}},
 	}
 }

--- a/http_client.go
+++ b/http_client.go
@@ -162,6 +162,7 @@ func newSingleHostClient() *http.Client {
 			IdleConnTimeout:       90 * time.Second,
 			TLSHandshakeTimeout:   10 * time.Second,
 			ExpectContinueTimeout: 1 * time.Second,
+			DisableKeepAlives:     true,
 		}},
 	}
 }


### PR DESCRIPTION
I made these changes when I was debugging performance issues in my go service.

It ensures that file descriptors can be reused for the http client, and it makes sure that idle connections are closed more timely:

* https://github.com/google/go-github/pull/317
* https://medium.com/@p408865/til-go-http-client-reuse-connection-5d8c48731dec

