### PR TITLE
Fix structure variable ordering to ensure variable locations are compliant with atomic 64-bit alignment requirements.

### DIFF
--- a/atomicnum.go
+++ b/atomicnum.go
@@ -5,6 +5,18 @@ import (
 	"sync/atomic"
 )
 
+/*
+  From the Go sync/atomic docs:
+
+  > On ARM, x86-32, and 32-bit MIPS, it is the caller's responsibility to arrange
+  > for 64-bit alignment of 64-bit words accessed atomically. The first word in a
+  > variable or in an allocated struct, array, or slice can be relied upon to be
+  > 64-bit aligned.
+
+  So to avoid SIGSEGVs on these platforms, make sure the pointers passed into
+  these methods come from variables that are properly aligned.
+*/
+
 func addFloat64(addr *uint64, delta float64) {
 	for {
 		old := loadFloat64(addr)

--- a/counter.go
+++ b/counter.go
@@ -8,13 +8,15 @@ package spectator
 //
 // https://netflix.github.io/spectator/en/latest/intro/counter/
 type Counter struct {
-	id    *Id
 	count uint64
+	// Pointers need to be after counters to ensure 64-bit alignment. See
+	// note in atomicnum.go
+	id    *Id
 }
 
 // NewCounter generates a new counter, using the provided meter identifier.
 func NewCounter(id *Id) *Counter {
-	return &Counter{id, 0}
+	return &Counter{0, id}
 }
 
 // MeterId returns the meter identifier.

--- a/dist_summary.go
+++ b/dist_summary.go
@@ -12,17 +12,19 @@ import (
 //
 // https://netflix.github.io/spectator/en/latest/intro/dist-summary/
 type DistributionSummary struct {
-	id          *Id
 	count       int64
 	totalAmount int64
 	totalSqBits uint64
 	max         int64
+	// Pointers need to be after counters to ensure 64-bit alignment. See
+	// note in atomicnum.go
+	id          *Id
 }
 
 // NewDistributionSummary generates a new distribution summary, using the
 // provided meter identifier.
 func NewDistributionSummary(id *Id) *DistributionSummary {
-	return &DistributionSummary{id, 0, 0, 0, 0}
+	return &DistributionSummary{0, 0, 0, 0, id}
 }
 
 // MeterId returns the meter identifier.

--- a/gauge.go
+++ b/gauge.go
@@ -11,13 +11,15 @@ import "math"
 //
 // https://netflix.github.io/spectator/en/latest/intro/gauge/
 type Gauge struct {
-	id        *Id
 	valueBits uint64
+	// Pointers need to be after counters to ensure 64-bit alignment. See
+	// note in atomicnum.go
+	id        *Id
 }
 
 // NewGauge generates a new gauge, using the provided meter identifier.
 func NewGauge(id *Id) *Gauge {
-	return &Gauge{id, math.Float64bits(math.NaN())}
+	return &Gauge{math.Float64bits(math.NaN()), id}
 }
 
 // MeterId returns the meter identifier.

--- a/monotonic_counter.go
+++ b/monotonic_counter.go
@@ -8,9 +8,11 @@ import "sync/atomic"
 //
 // https://netflix.github.io/spectator/en/latest/intro/gauge/#monotonic-counters
 type MonotonicCounter struct {
+	value    int64
+	// Pointers need to be after counters to ensure 64-bit alignment. See
+	// note in atomicnum.go
 	registry *Registry
 	id       *Id
-	value    int64
 	counter  *Counter
 }
 
@@ -24,7 +26,7 @@ func NewMonotonicCounter(registry *Registry, name string, tags map[string]string
 // NewMonotonicCounterWithId generates a new monotonic counter, using the
 // provided meter identifier.
 func NewMonotonicCounterWithId(registry *Registry, id *Id) *MonotonicCounter {
-	return &MonotonicCounter{registry, id, 0, nil}
+	return &MonotonicCounter{0, registry, id, nil}
 }
 
 // Set adds amount to the current counter.

--- a/timer.go
+++ b/timer.go
@@ -8,16 +8,18 @@ import (
 // Timer is used to measure how long (in seconds) some event is taking. This
 // type is safe for concurrent use.
 type Timer struct {
-	id             *Id
 	count          int64
 	totalTime      int64
 	totalOfSquares uint64
 	max            int64
+	// Pointers need to be after counters to ensure 64-bit alignment. See
+	// note in atomicnum.go
+	id             *Id
 }
 
 // NewTimer generates a new timer, using the provided meter identifier.
 func NewTimer(id *Id) *Timer {
-	return &Timer{id, 0, 0, 0, 0}
+	return &Timer{0, 0, 0, 0, id}
 }
 
 // MeterId returns the meter identifier.


### PR DESCRIPTION
I ran into an issue today building a 32-bit binary and went down a rabbit finding my way to this [bit of the sync/atomic go docs](https://golang.org/pkg/sync/atomic/#pkg-note-BUG):

> On ARM, x86-32, and 32-bit MIPS, it is the caller's responsibility to arrange for 64-bit alignment of 64-bit words accessed atomically. The first word in a variable or in an allocated struct, array, or slice can be relied upon to be 64-bit aligned.

So while we probably don't have that many occasions to build 32-bit applications, it'd be nice to save anyone else from similar grief. The fix here is apparently to lay out the data structures where these atomic methods are used such that the 64-bit numeric values are aligned, which is most easily done by moving all pointers to the bottom of the data structures.