### PR TITLE
Fix race in MapKey

### DIFF
--- a/clock.go
+++ b/clock.go
@@ -1,6 +1,9 @@
 package spectator
 
-import "time"
+import (
+	"sync/atomic"
+	"time"
+)
 
 // Clock is an interface to provide functionality to create timing/latency
 // metrics.
@@ -38,17 +41,17 @@ func (c *ManualClock) Now() time.Time {
 
 // Nanos returns the internal nanoseconds. Satisfies Clock interface.
 func (c *ManualClock) Nanos() int64 {
-	return c.nanos
+	return atomic.LoadInt64(&c.nanos)
 }
 
 // SetFromDuration takes a duration, and sets that to the internal nanosecond
 // value. The .Now() probably has no value when this is used to populate the
 // data.
 func (c *ManualClock) SetFromDuration(duration time.Duration) {
-	c.nanos = int64(duration)
+	atomic.StoreInt64(&c.nanos, int64(duration))
 }
 
 // SetNanos sets the internal nanoseconds value directly.
 func (c *ManualClock) SetNanos(nanos int64) {
-	c.nanos = nanos
+	atomic.StoreInt64(&c.nanos, nanos)
 }

--- a/http_client_test.go
+++ b/http_client_test.go
@@ -86,7 +86,7 @@ func TestHttpClient_PostJson503_Compress(t *testing.T) {
 		return meters[i].MeterId().Tags()["ipc.attempt"] < meters[j].MeterId().Tags()["ipc.attempt"]
 	})
 	if len(meters) != 3 {
-		t.Fatal("Expected 1 meter, got", len(meters))
+		t.Fatal("Expected 3 meters, got", len(meters))
 	}
 
 	baseTags := map[string]string{
@@ -353,7 +353,7 @@ func TestHttpClient_PostJson503(t *testing.T) {
 		return meters[i].MeterId().Tags()["ipc.attempt"] < meters[j].MeterId().Tags()["ipc.attempt"]
 	})
 	if len(meters) != 3 {
-		t.Fatal("Expected 1 meter, got", len(meters))
+		t.Fatal("Expected 3 meters, got", len(meters))
 	}
 
 	baseTags := map[string]string{

--- a/id_test.go
+++ b/id_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"reflect"
+	"sync"
 	"testing"
 )
 
@@ -14,11 +15,31 @@ func TestId_mapKey(t *testing.T) {
 		t.Error("Expected foo, got", k)
 	}
 
-	reusesKey := Id{"foo", nil, "bar"}
+	reusesKey := Id{
+		name: "foo",
+		key:  "bar",
+	}
 	k2 := reusesKey.MapKey()
 	if k2 != "bar" {
 		t.Error("Expected MapKey to be reused: bar !=", k2)
 	}
+}
+
+func TestId_mapKeyConcurrent(t *testing.T) {
+	id := NewId("foo", nil)
+
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+	go func() {
+		_ = id.MapKey()
+		wg.Done()
+	}()
+	go func() {
+		_ = id.MapKey()
+		wg.Done()
+	}()
+
+	wg.Wait()
 }
 
 func TestId_mapKeySortsTags(t *testing.T) {


### PR DESCRIPTION
Fix race in `ManualClock`
Fix race in `MapKey`

MapKey was previously exported in https://github.com/Netflix/spectator-go/pull/42

FWIW, the current MapKey behavior could done more safely by introducing a lock rather than precomputing during construction, as introduced in this change. I chose to avoid the lock on the assumption that users are not depending on the JIT computation behavior.

Make MapKey() thread-safe by precomputing the value during construction.
This does not change any documented behavior of Id, which is immutable
(apart from one case mentioned below). However, the lack of map clone in
Tags() means that previously a caller could construct a new Id, calls
Tags(), modify the resulting map, and then call MapKey(). This would
result in a different output after this change, which captures the tags
at construction.

I believe this is more aligned with the intent of this type. The
documented behavior mentions the lack of clone to warn the user of
modifying the map from Tags(), but does not prevent it.

Interestingly, in the previous implementation, this was likely hidden by the Registry calling 
MapKey(), which uses a mutex for registration via a blocking call to NewTimer() or friends. I suspect
that the most common use of Id has been to construct and immediately
register. Since the value for MapKey() was previously precomputed
lazily, subsequent calls after registration were threadsafe.

The use-case that led to this discovery is relying on `MapKey()` to populate a local cache of `Id` values for use by `PersistentTimers`. The cache was introduced to avoid the relatively expensive construction of a `PersistentTimer` (and its underlying side effects) that may already have been created. 



Race example for `ManualClock`
```➜ go test -race ./...
DEBUG: 2021/03/01 12:54:54 posting data to http://127.0.0.1:38093, payload 2 bytes
DEBUG: 2021/03/01 12:54:54 response HTTP 200:
DEBUG: 2021/03/01 12:54:54 posting data to http://127.0.0.1:36927, payload 2 bytes
INFO: 2021/03/01 12:54:54 Timed out attempting to POST to http://127.0.0.1:36927
==================
WARNING: DATA RACE
Read at 0x00c000280330 by goroutine 67:
  github.com/Netflix/spectator-go.(*ManualClock).Nanos()
      /home/r2/code/ext/spectator-go/clock.go:41 +0x3a
  github.com/Netflix/spectator-go.(*LogEntry).Log()
      /home/r2/code/ext/spectator-go/log_entry.go:54 +0x6c
  github.com/Netflix/spectator-go.(*HttpClient).doHttpPost()
      /home/r2/code/ext/spectator-go/http_client.go:135 +0x74c
  github.com/Netflix/spectator-go.(*HttpClient).PostJson()
      /home/r2/code/ext/spectator-go/http_client.go:143 +0x145
  github.com/Netflix/spectator-go.TestHttpClient_PostJsonTimeout()
      /home/r2/code/ext/spectator-go/http_client_test.go:124 +0xa6e
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1194 +0x202

Previous write at 0x00c000280330 by goroutine 73:
  github.com/Netflix/spectator-go.(*ManualClock).SetFromDuration()
      /home/r2/code/ext/spectator-go/clock.go:48 +0x4d
  github.com/Netflix/spectator-go.TestHttpClient_PostJsonTimeout.func1()
      /home/r2/code/ext/spectator-go/http_client_test.go:108 +0x44
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/go/src/net/http/server.go:2069 +0x51
  net/http.serverHandler.ServeHTTP()
      /usr/local/go/src/net/http/server.go:2887 +0xca
  net/http.(*conn).serve()
      /usr/local/go/src/net/http/server.go:1952 +0x87d

Goroutine 67 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1239 +0x5d7
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1512 +0xa6
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1194 +0x202
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1510 +0x612
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1418 +0x3b3
  main.main()
      _testmain.go:135 +0x236

Goroutine 73 (running) created at:
  net/http.(*Server).Serve()
      /usr/local/go/src/net/http/server.go:3013 +0x644
  net/http/httptest.(*Server).goServe.func1()
      /usr/local/go/src/net/http/httptest/server.go:308 +0xd8
==================
--- FAIL: TestHttpClient_PostJsonTimeout (0.00s)
    testing.go:1093: race detected during execution of test
DEBUG: 2021/03/01 12:54:54 posting data to http://127.0.0.1:34955, payload 2 bytes
DEBUG: 2021/03/01 12:54:54 response HTTP 503:
DEBUG: 2021/03/01 12:54:54 posting data to http://127.0.0.1:34955, payload 2 bytes
DEBUG: 2021/03/01 12:54:54 response HTTP 503:
DEBUG: 2021/03/01 12:54:54 posting data to http://127.0.0.1:34955, payload 2 bytes
DEBUG: 2021/03/01 12:54:54 response HTTP 503:
INFO: 2021/03/01 12:54:55 registry config has no uri. Ignoring Start request
DEBUG: 2021/03/01 12:54:55 Got 1 measurements
DEBUG: 2021/03/01 12:54:55 Sending 1 measurements to http://127.0.0.1:38663
DEBUG: 2021/03/01 12:54:55 posting data to http://127.0.0.1:38663, payload 161 bytes
DEBUG: 2021/03/01 12:54:55 response HTTP 200:
DEBUG: 2021/03/01 12:54:55 Got 3 measurements
DEBUG: 2021/03/01 12:54:55 Sending 3 measurements to http://127.0.0.1:39485
DEBUG: 2021/03/01 12:54:55 posting data to http://127.0.0.1:39485, payload 248 bytes
DEBUG: 2021/03/01 12:54:55 response HTTP 202:
INFO: 2021/03/01 12:54:55 1 measurement(s) dropped due to validation errors: key too short: [o] (1 < 2)
DEBUG: 2021/03/01 12:54:55 Got 1 measurements
DEBUG: 2021/03/01 12:54:55 Sending 1 measurements to http://127.0.0.1:33923
DEBUG: 2021/03/01 12:54:55 posting data to http://127.0.0.1:33923, payload 161 bytes
DEBUG: 2021/03/01 12:54:55 response HTTP 200:
DEBUG: 2021/03/01 12:54:55 Got 6 measurements
DEBUG: 2021/03/01 12:54:55 Sending 6 measurements to http://127.0.0.1:33923
DEBUG: 2021/03/01 12:54:55 posting data to http://127.0.0.1:33923, payload 850 bytes
DEBUG: 2021/03/01 12:54:55 response HTTP 200:
DEBUG: 2021/03/01 12:54:55 Got 6 measurements
DEBUG: 2021/03/01 12:54:55 Got 5 measurements
DEBUG: 2021/03/01 12:54:55 Sending 5 measurements to http://127.0.0.1:33923
DEBUG: 2021/03/01 12:54:55 posting data to http://127.0.0.1:33923, payload 724 bytes
DEBUG: 2021/03/01 12:54:55 response HTTP 200:
FAIL
FAIL    github.com/Netflix/spectator-go 1.053s
ok      github.com/Netflix/spectator-go/histogram       0.159s
FAIL
```

Race example for `MapKey()` -- this is the test added in this changeset, but without the change to MapKey(). The scope of the test run is limited due to an unrelated test failure in `TestHttpClient_PostJsonTimeout` that is seemingly only triggered with the race detector enabled. i.e. this failure occurs on `master`.
```
➜ go test -race ./...  -run TestId
==================
WARNING: DATA RACE
Write at 0x00c00007efd8 by goroutine 9:
  github.com/Netflix/spectator-go.(*Id).MapKey()
      /home/r2/code/ext/spectator-go/id.go:55 +0x55a
  github.com/Netflix/spectator-go.TestId_mapKeyConcurrent.func1()
      /home/r2/code/ext/spectator-go/id_test.go:31 +0x38

Previous read at 0x00c00007efd8 by goroutine 10:
  github.com/Netflix/spectator-go.(*Id).MapKey()
      /home/r2/code/ext/spectator-go/id.go:20 +0x64
  github.com/Netflix/spectator-go.TestId_mapKeyConcurrent.func2()
      /home/r2/code/ext/spectator-go/id_test.go:35 +0x38

Goroutine 9 (running) created at:
  github.com/Netflix/spectator-go.TestId_mapKeyConcurrent()
      /home/r2/code/ext/spectator-go/id_test.go:30 +0xd8
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1194 +0x202

Goroutine 10 (finished) created at:
  github.com/Netflix/spectator-go.TestId_mapKeyConcurrent()
      /home/r2/code/ext/spectator-go/id_test.go:34 +0x104
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1194 +0x202
==================
--- FAIL: TestId_mapKeyConcurrent (0.00s)
    testing.go:1093: race detected during execution of test
FAIL
FAIL    github.com/Netflix/spectator-go 0.007s
ok      github.com/Netflix/spectator-go/histogram       (cached) [no tests to run]
FAIL
```