### PR TITLE
fix file descriptor metric names

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -21,8 +21,8 @@ func goRuntimeStats(s *sysStatsCollector) {
 func CollectSysStats(registry *Registry) {
 	var s sysStatsCollector
 	s.registry = registry
-	s.maxOpen = registry.Gauge("fh.allocated", nil)
-	s.curOpen = registry.Gauge("fh.max", nil)
+	s.maxOpen = registry.Gauge("fh.max", nil)
+	s.curOpen = registry.Gauge("fh.allocated", nil)
 	s.numGoroutines = registry.Gauge("go.numGoroutines", nil)
 
 	ticker := time.NewTicker(30 * time.Second)


### PR DESCRIPTION
This commit fixes a bug that was introduced by the following commit:

https://github.com/Netflix/spectator-go/commit/375b638ffabe980c39294486dc6e03a9993a2fb3

When the file descriptor metric names were updated from `fh.maxOpen` and
`fh.curOpen` to `fh.allocated` and `fh.max`, the names were swapped. The
`allocated` metric should track the number of file descriptors opened,
and the `max` metric should track the number of file descriptors
configured.