### PR TITLE
HttpClient Modifications

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,5 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/json-iterator/go v1.1.10 h1:Kz6Cvnvv2wGdaG/V8yMvfkmNiXq9Ya2KUv4rouJJr68=
@@ -11,8 +12,10 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 h1:Esafd1046DLD
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2ByMI1Shq4Y6oRJo21SGJA=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/http_client.go
+++ b/http_client.go
@@ -102,13 +102,13 @@ const maxAttempts = 3
 
 // HttpResponse represents a read HTTP response.
 type HttpResponse struct {
-	status int
-	body   []byte
+	Status int
+	Body   []byte
 }
 
 func (h *HttpClient) doHttpPost(uri string, jsonBytes []byte, attemptNumber int) (response HttpResponse, err error) {
 	var willRetry bool
-	response.status = -1
+	response.Status = -1
 	log := h.registry.GetLogger()
 	var req *http.Request
 	var cleanup func()
@@ -149,22 +149,22 @@ func (h *HttpClient) doHttpPost(uri string, jsonBytes []byte, attemptNumber int)
 				log.Errorf("Unable to close body: %v", err)
 			}
 		}()
-		response.status = resp.StatusCode
+		response.Status = resp.StatusCode
 		entry.SetStatusCode(resp.StatusCode)
 		var body []byte
-		response.body, err = ioutil.ReadAll(resp.Body)
+		response.Body, err = ioutil.ReadAll(resp.Body)
 		if err != nil {
 			log.Errorf("Unable to read response body: %v", err)
 			return
 		}
 		log.Debugf("response HTTP %d: %s", resp.StatusCode, body)
-		if response.status >= 200 && response.status < 300 {
+		if response.Status >= 200 && response.Status < 300 {
 			entry.SetSuccess()
 		} else {
 			entry.SetError("http-error")
 		}
 		// only retry 503s for now
-		willRetry = response.status == 503
+		willRetry = response.Status == 503
 	}
 
 	final := !(willRetry && (attemptNumber+1) < maxAttempts)
@@ -178,7 +178,7 @@ func (h *HttpClient) doHttpPost(uri string, jsonBytes []byte, attemptNumber int)
 func (h *HttpClient) PostJson(uri string, jsonBytes []byte) (response HttpResponse, err error) {
 	for attemptNumber := 0; attemptNumber < maxAttempts; attemptNumber += 1 {
 		response, err = h.doHttpPost(uri, jsonBytes, attemptNumber)
-		willRetry := err == nil && response.status == 503
+		willRetry := err == nil && response.Status == 503
 		if !willRetry {
 			break
 		}

--- a/http_client_test.go
+++ b/http_client_test.go
@@ -77,8 +77,8 @@ func TestHttpClient_PostJson503_Compress(t *testing.T) {
 		t.Fatal("Unexpected error", err)
 	}
 
-	if resp.status != 503 {
-		t.Error("Expected 503 response. Got", resp.status)
+	if resp.Status != 503 {
+		t.Error("Expected 503 response. Got", resp.Status)
 	}
 
 	meters := myMeters(registry)
@@ -162,8 +162,8 @@ func TestHttpClient_PostJsonOk_Compress(t *testing.T) {
 		t.Error("Unexpected error", err)
 	}
 
-	if resp.status != 200 {
-		t.Error("Expected 200 response. Got", resp.status)
+	if resp.Status != 200 {
+		t.Error("Expected 200 response. Got", resp.Status)
 	}
 
 	meters := myMeters(registry)
@@ -227,8 +227,8 @@ func TestHttpClient_PostJsonOk(t *testing.T) {
 		t.Error("Unexpected error", err)
 	}
 
-	if resp.status != 200 {
-		t.Error("Expected 200 response. Got", resp.status)
+	if resp.Status != 200 {
+		t.Error("Expected 200 response. Got", resp.Status)
 	}
 
 	meters := myMeters(registry)
@@ -344,8 +344,8 @@ func TestHttpClient_PostJson503(t *testing.T) {
 		t.Fatal("Unexpected error", err)
 	}
 
-	if resp.status != 503 {
-		t.Error("Expected 503 response. Got", resp.status)
+	if resp.Status != 503 {
+		t.Error("Expected 503 response. Got", resp.Status)
 	}
 
 	meters := myMeters(registry)

--- a/registry.go
+++ b/registry.go
@@ -264,13 +264,13 @@ func (r *Registry) sendBatch(measurements []Measurement) {
 		} else {
 			sent := int64(0)
 			dropped := int64(0)
-			if resp.status == 200 {
+			if resp.Status == 200 {
 				sent = numMeasurements
-			} else if resp.status < 500 {
+			} else if resp.Status < 500 {
 				var atlasResponse atlasMessage
-				err = json.Unmarshal(resp.body, &atlasResponse)
+				err = json.Unmarshal(resp.Body, &atlasResponse)
 				if err != nil {
-					r.config.Log.Errorf("%d measurement(s) dropped. Http status: %d", numMeasurements, resp.status)
+					r.config.Log.Errorf("%d measurement(s) dropped. Http status: %d", numMeasurements, resp.Status)
 					r.droppedOther.Add(numMeasurements)
 				} else {
 					dropped = int64(atlasResponse.ErrorCount)


### PR DESCRIPTION
There are two primary modifications in this PR:

1.) Make the `HttpResponse` object actually usable by exporting (making public) its fields `Status` and `Body`. This makes the `spectator.HttpClient` a more usable client for workloads that need an instrumented HTTP client.

2.) Add a new `HttpClientOption` for modifying the underlying HTTP client. I did this to enable some unit testing where I needed to replace the client and/or `http.RoundTripper`. A more idiomatic approach may be to just make the `*http.Client` exported as well.