### PR TITLE
Avoid spurious error messages from failure to close HTTP response body

### DIFF
--- a/http_client.go
+++ b/http_client.go
@@ -150,11 +150,7 @@ func (h *HttpClient) doHttpPost(uri string, jsonBytes []byte, attemptNumber int)
 			log.Infof("Unable to POST to %s: %v", uri, err)
 		}
 	} else {
-		defer func() {
-			if err = resp.Body.Close(); err != nil {
-				log.Errorf("Unable to close body: %v", err)
-			}
-		}()
+		defer resp.Body.Close()
 		response.Status = resp.StatusCode
 		entry.SetStatusCode(resp.StatusCode)
 		var body []byte


### PR DESCRIPTION
We're seeing log spam with lines like this:

    ERROR Unable to close body: context cancelled
    ERROR Could not post measurements: HTTP 200 context canceled

This seems to come from the error check on resp.Body.Close. By assigning
to `err`, it causes doHttpPost to return an error. It seems better to
ignore failures to close the body, and avoid these noisy log messages.