### PR TITLE
add payload debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ This implements a basic [Spectator](https://github.com/Netflix/spectator)
 library for instrumenting golang applications, sending metrics to an Atlas
 aggregator service.
 
+## Debugging Metric Payloads
+
+Set the following environment variable to enumerate the metrics payloads which
+are sent to the backend. This is useful for debugging metric publishing issues.
+
+```
+export SPECTATOR_DEBUG_PAYLOAD=1
+```
+
 ## Instrumenting Code
 
 ```go
@@ -96,7 +105,6 @@ func main() {
 		server.Handle(req)
 	}
 }
-
 ```
 
 


### PR DESCRIPTION
There are variety of ways to handle logging in Go, which means that there is
no simple test available for detecting the current log level. As such, this
change introduces an environment variable SPECTATOR_DEBUG_PAYLOAD which can
be set to 1 to enable logging of all Ids and Values in a metrics payload that
is sent to the backend. This value is read once at startup and cached in the
main Registry struct.