### PR TITLE
revert to golangci-lint

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.14, 1.15, 1.16, 1.17]
+        go-version: [1.13, 1.14, 1.15, 1.16, 1.17]
     steps:
       - uses: actions/checkout@v2
 
@@ -19,7 +19,8 @@ jobs:
       - name: Install dependencies
         run: |
           go version
-          go get -u golang.org/x/lint/golint
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.43.0
+          golangci-lint --version
 
       - name: Run build
         run: |
@@ -28,8 +29,8 @@ jobs:
       - name: Run tests
         run: |
           go test -v
+          golangci-lint run
 
-      - name: Run vet & lint
+      - name: Run linter
         run: |
-          go vet .
-          golint .
+          golangci-lint run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.14, 1.15, 1.16, 1.17]
+        go-version: [1.13, 1.14, 1.15, 1.16, 1.17]
     steps:
       - uses: actions/checkout@v2
 
@@ -24,7 +24,8 @@ jobs:
       - name: Install dependencies
         run: |
           go version
-          go get -u golang.org/x/lint/golint
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.43.0
+          golangci-lint --version
 
       - name: Run build
         run: |
@@ -33,8 +34,8 @@ jobs:
       - name: Run tests
         run: |
           go test -v
+          golangci-lint run
 
-      - name: Run vet & lint
+      - name: Run linter
         run: |
-          go vet .
-          golint .
+          golangci-lint run

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.14, 1.15, 1.16, 1.17]
+        go-version: [1.13, 1.14, 1.15, 1.16, 1.17]
     steps:
       - uses: actions/checkout@v2
 
@@ -23,7 +23,8 @@ jobs:
       - name: Install dependencies
         run: |
           go version
-          go get -u golang.org/x/lint/golint
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.43.0
+          golangci-lint --version
 
       - name: Run build
         run: |
@@ -32,8 +33,8 @@ jobs:
       - name: Run tests
         run: |
           go test -v
+          golangci-lint run
 
-      - name: Run vet & lint
+      - name: Run linter
         run: |
-          go vet .
-          golint .
+          golangci-lint run

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,3 @@
+linters:
+  disable:
+    - errcheck


### PR DESCRIPTION
The standard golint is very strict and generates unnecessary errors.