### PR TITLE
log http body on error response when unmarshalling fails

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -289,7 +289,7 @@ func (r *Registry) sendBatch(measurements []Measurement) {
 				var atlasResponse atlasMessage
 				err = json.Unmarshal(resp.Body, &atlasResponse)
 				if err != nil {
-					r.config.Log.Errorf("%d measurement(s) dropped. Http status: %d", numMeasurements, resp.Status)
+					r.config.Log.Errorf("%d measurement(s) dropped, HTTP status: %d, HTTP body: %s", numMeasurements, resp.Status, resp.Body)
 					r.droppedOther.Add(numMeasurements)
 				} else {
 					dropped = int64(atlasResponse.ErrorCount)


### PR DESCRIPTION
The Atlas response has a field `message` which may be either a string or a list of strings. The most common case, for validation errors, is a list of strings. To provide a little more feedback when unusual errors occur, we will now log the HTTP body for messages that cannot be unmarshalled due to this type mismatch. This will cover both the single string variant of Atlas responses, as well as any error responses that may originate from load balancers.