### PR TITLE
registry: adds spectator.registrySize meter

### DIFF
--- a/log_entry_test.go
+++ b/log_entry_test.go
@@ -42,6 +42,11 @@ func TestLogEntry_Log(t *testing.T) {
 		"ipc.client.call|totalOfSquares": 0.25,
 		"ipc.client.call|max":            0.5,
 		"ipc.client.call|count":          1,
+
+		"spectator.registrySize|count":          1,
+		"spectator.registrySize|max":            6,
+		"spectator.registrySize|totalAmount":    6,
+		"spectator.registrySize|totalOfSquares": 36,
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("Expected %v\nGot %v", expected, actual)
@@ -72,6 +77,11 @@ func TestLogEntry_LogCustom(t *testing.T) {
 		"ipc.client.call|max":              0.5,
 		"ipc.client.call|count":            1,
 		"ipc.client.call|percentile|T007D": 1,
+
+		"spectator.registrySize|count":          1,
+		"spectator.registrySize|max":            7,
+		"spectator.registrySize|totalAmount":    7,
+		"spectator.registrySize|totalOfSquares": 49,
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("Expected %v\nGot %v", expected, actual)

--- a/memstats_test.go
+++ b/memstats_test.go
@@ -90,9 +90,11 @@ func TestUpdateMemStats(t *testing.T) {
 	}
 	for _, m := range ms {
 		name := m.MeterId().name
-		if name == "gc.pauseTime" {
+		switch name {
+		case "gc.pauseTime":
 			assertTimer(t, m.(*Timer), 1, 10*1e6, 100*1e12, 10*1e6)
-		} else {
+		case "spectator.registrySize":
+		default:
 			expected := expectedValues[name]
 			measures := m.Measure()
 			if expected > 0 {


### PR DESCRIPTION
This diff adds the spectator.registrySize meter that is reported by the Java implementation and spectatord. This dist summary records the total number of meters in the registry. This is useful if one wants to know how many meters are in memory and whether that number is significantly different from the number of measurements being reported.

For the sake of preserving backwards compatability I opted to update this when `Registry.Measurements` is called as we already unlock the registry there.

As an alternative, I considered adding a `Registry.Size` method that would allow callers to report this metric on their own but that creates more work for callers.