### PR TITLE
Updates GH Actions workflows and fixes several small bugs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Run tests
         run: |
-          go test -v
+          go test -race -v ./...
           golangci-lint run
 
       - name: Run linter

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Run tests
         run: |
-          go test -v
+          go test -race -v ./...
           golangci-lint run
 
       - name: Run linter

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run tests
         run: |
-          go test -v
+          go test -race -v ./...
           golangci-lint run
 
       - name: Run linter

--- a/histogram/percentile_distsummary_test.go
+++ b/histogram/percentile_distsummary_test.go
@@ -1,10 +1,11 @@
 package histogram
 
 import (
-	"github.com/Netflix/spectator-go"
 	"math"
 	"reflect"
 	"testing"
+
+	"github.com/Netflix/spectator-go"
 )
 
 func TestPercentileDistributionSummary_Basic(t *testing.T) {
@@ -16,7 +17,7 @@ func TestPercentileDistributionSummary_Basic(t *testing.T) {
 	ds.Record(3000) // 0x2F
 	ds.Record(3001) // 0x2F
 
-	ms := r.Measurements()
+	ms := filterRegistrySize(r.Measurements())
 	measurementMap := measurementsToMap(ms)
 	var expected = make(map[string]float64)
 	expected["ds|count"] = 4

--- a/histogram/percentile_timer_test.go
+++ b/histogram/percentile_timer_test.go
@@ -2,11 +2,12 @@ package histogram
 
 import (
 	"fmt"
-	"github.com/Netflix/spectator-go"
 	"math"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/Netflix/spectator-go"
 )
 
 func makeConfig(uri string) *spectator.Config {
@@ -95,6 +96,18 @@ func measurementsToMap(ms []spectator.Measurement) map[string]float64 {
 	return result
 }
 
+func filterRegistrySize(ms []spectator.Measurement) []spectator.Measurement {
+	var filtered []spectator.Measurement
+	for _, m := range ms {
+		if m.Id().Name() == "spectator.registrySize" {
+			continue
+		}
+
+		filtered = append(filtered, m)
+	}
+	return filtered
+}
+
 func TestPercentileTimer_Measurements(t *testing.T) {
 	r := spectator.NewRegistry(config)
 	t1 := NewPercentileTimer(r, "test", map[string]string{})
@@ -102,7 +115,7 @@ func TestPercentileTimer_Measurements(t *testing.T) {
 	t1.Record(2 * time.Second)
 	t1.Record(40 * time.Second)
 
-	ms := r.Measurements()
+	ms := filterRegistrySize(r.Measurements())
 	ms_map := measurementsToMap(ms)
 	var expected = make(map[string]float64)
 	expected["test|max"] = 40
@@ -120,7 +133,7 @@ func TestPercentileTimer_Measurements(t *testing.T) {
 	t1.Record(40 * time.Second)
 	t1.Record(140 * time.Second)
 	t1.Record(240 * time.Second)
-	ms = r.Measurements()
+	ms = filterRegistrySize(r.Measurements())
 	ms_map = measurementsToMap(ms)
 	expected["test|max"] = 240
 	expected["test|count"] = 4

--- a/monotonic_counter_test.go
+++ b/monotonic_counter_test.go
@@ -44,3 +44,15 @@ func TestMonotonicCounterStartingAt0(t *testing.T) {
 		t.Errorf("Count should be 1, got %f", c.counter.Count())
 	}
 }
+
+func TestMonotonicCounterThreadSafety(t *testing.T) {
+	r := NewRegistry(makeConfig("http://example.org"))
+	c := NewMonotonicCounter(r, "mono", nil)
+
+	go func() {
+		c.Set(0)
+	}()
+	go func() {
+		c.Set(0)
+	}()
+}


### PR DESCRIPTION
Deets below, happy to break this into multiple PRs if that's preferred.

**[e12d39c] fixes race in monotonic counter**
The previous implementation of MonotonicCounter.Set is not thread safe
as we check/set a poitner without mutual exclusion.

This diff adds and test that repros this if the race detector is enabled,
and fixes the issue by initializing the underlying counter using sync.Once.

**[41b5a0b] histogram: fixes unit tests that were broken by #70**

**[e7885fb] github: updates go test command in CI workflows**
The `go test` only runs the tests in the top level package. This updates
the command with to run the tests for every package and enables the race
detector.

context: While investigating a potential bug I noticed that #70
broke some tests that were not caught by CI.
