### PR TITLE
http: removes error log from http response body close

### DIFF
--- a/http_client.go
+++ b/http_client.go
@@ -162,11 +162,7 @@ func (h *HttpClient) doHttpPost(uri string, jsonBytes []byte, attemptNumber int)
 			log.Infof("Unable to POST to %s: %v", uri, err)
 		}
 	} else {
-		defer func() {
-			if err = resp.Body.Close(); err != nil {
-				log.Errorf("Unable to close body: %v", err)
-			}
-		}()
+		defer resp.Body.Close()
 		response.Status = resp.StatusCode
 		entry.SetStatusCode(resp.StatusCode)
 		var body []byte


### PR DESCRIPTION
Ressurrecting #59

Occasionally we see context cancelation errors in our logs like the following:

`Unable to close body: net/http: request canceled`

This is creating noise in one of our services as we have pretty fastidious exception monitoring. In my experience "errors" that pop up while closing the request body aren't actionable/indicitive of an issue and most Go codebases don't bother logging them.

This change removes the log message. If there is a strong desire to log these errors then I'd recommend we change it to a warning or debug level message.