### PR TITLE
Adding GetWriter so it can be used from other packages

### DIFF
--- a/spectator/registry.go
+++ b/spectator/registry.go
@@ -46,6 +46,7 @@ type RegistryInterface interface {
 	PercentileDistributionSummaryWithId(id *meter.Id) *meter.PercentileDistributionSummary
 	PercentileTimer(name string, tags map[string]string) *meter.PercentileTimer
 	PercentileTimerWithId(id *meter.Id) *meter.PercentileTimer
+	GetWriter() writer.Writer
 	Close()
 }
 
@@ -229,6 +230,10 @@ func (r *Registry) PercentileTimer(name string, tags map[string]string) *meter.P
 
 func (r *Registry) PercentileTimerWithId(id *meter.Id) *meter.PercentileTimer {
 	return meter.NewPercentileTimer(id, r.writer)
+}
+
+func (r *Registry) GetWriter() writer.Writer {
+	return r.writer
 }
 
 func (r *Registry) Close() {


### PR DESCRIPTION
Need this so that runtime-metrics package can retrieve the MemoryWriter to do asserts in tests.