### PR TITLE
add character validation

### DIFF
--- a/spectator/meter/id.go
+++ b/spectator/meter/id.go
@@ -2,6 +2,7 @@ package meter
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -24,6 +25,8 @@ var builderPool = &sync.Pool{
 		return &strings.Builder{}
 	},
 }
+
+var invalidCharacters = regexp.MustCompile(`[^-._A-Za-z0-9~^]`)
 
 // MapKey computes and saves a key within the struct to be used to uniquely
 // identify this *Id in a map. This does use the information from within the
@@ -162,9 +165,11 @@ func (id *Id) WithTags(tags map[string]string) *Id {
 }
 
 func toSpectatorId(name string, tags map[string]string) string {
-	result := name
+	result := invalidCharacters.ReplaceAllString(name, "_")
 
 	for k, v := range tags {
+		k = invalidCharacters.ReplaceAllString(k, "_")
+		v = invalidCharacters.ReplaceAllString(v, "_")
 		result += fmt.Sprintf(",%s=%s", k, v)
 	}
 

--- a/spectator/meter/id_test.go
+++ b/spectator/meter/id_test.go
@@ -145,3 +145,18 @@ func TestToSpectatorId_EmptyTags(t *testing.T) {
 		t.Errorf("Expected '%s', got '%s'", expected, result)
 	}
 }
+
+func TestToSpectatorId_InvalidTags(t *testing.T) {
+	name := "test`!@#$%^&*()-=~_+[]{}\\|;:'\",<.>/?foo"
+	tags := map[string]string{
+		"tag1,:=": "value1,:=",
+		"tag2,;=": "value2,;=",
+	}
+
+	expected := "test______^____-_~______________.___foo,tag1___=value1___,tag2___=value2___"
+	result := toSpectatorId(name, tags)
+
+	if result != expected {
+		t.Errorf("Expected '%s', got '%s'", expected, result)
+	}
+}


### PR DESCRIPTION
It is easy enough to break spectatord protocol line parsing by using the line separator characters (,:=) in unexpected ways, such that it may not report a parsing error. Rather than trying to capture every possible edge case in the line parsing, the client library can perform basic character validation and substitution, following the same rules, so that invalid characters are changed to underscores (_).