### PR TITLE
Adding protocol parser for testing

### DIFF
--- a/spectator/protocol_parser.go
+++ b/spectator/protocol_parser.go
@@ -1,0 +1,33 @@
+package spectator
+
+import (
+	"fmt"
+	"github.com/Netflix/spectator-go/spectator/meter"
+	"strings"
+)
+
+// ParseProtocolLine parses a line of the spectator protocol. Utility exposed for testing.
+func ParseProtocolLine(line string) (string, *meter.Id, string, error) {
+	parts := strings.Split(line, ":")
+	if len(parts) != 3 {
+		return "", nil, "", fmt.Errorf("invalid line format")
+	}
+
+	meterSymbol := parts[0]
+	meterId := parts[1]
+	value := parts[2]
+
+	meterIdParts := strings.Split(meterId, ",")
+	name := meterIdParts[0]
+
+	tags := make(map[string]string)
+	for _, tag := range meterIdParts[1:] {
+		kv := strings.Split(tag, "=")
+		if len(kv) != 2 {
+			return "", nil, "", fmt.Errorf("invalid tag format")
+		}
+		tags[kv[0]] = kv[1]
+	}
+
+	return meterSymbol, meter.NewId(name, tags), value, nil
+}

--- a/spectator/protocol_parser_test.go
+++ b/spectator/protocol_parser_test.go
@@ -1,0 +1,65 @@
+package spectator
+
+import (
+	"testing"
+)
+
+func TestParseProtocolLineWithValidInput(t *testing.T) {
+	line := "c:meterId,tag1=value1,tag2=value2:value"
+	meterType, meterId, value, err := ParseProtocolLine(line)
+
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	if meterType != "c" {
+		t.Errorf("Expected 'c', got '%s'", meterType)
+	}
+
+	if meterId.Name() != "meterId" || meterId.Tags()["tag1"] != "value1" || meterId.Tags()["tag2"] != "value2" {
+		t.Errorf("Unexpected meterId: %v", meterId)
+	}
+
+	if value != "value" {
+		t.Errorf("Expected 'value', got '%s'", value)
+	}
+}
+
+func TestParseProtocolLineWithInvalidFormat(t *testing.T) {
+	line := "invalid_format_line"
+	_, _, _, err := ParseProtocolLine(line)
+
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+}
+
+func TestParseProtocolLineWithInvalidTagFormat(t *testing.T) {
+	line := "c:meterId=value=value2,tag1=value1,tag2:value"
+	_, _, _, err := ParseProtocolLine(line)
+
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+}
+
+func TestParseGaugeWithTTL(t *testing.T) {
+	line := "g,120:test:1"
+	meterSymbol, meterId, value, err := ParseProtocolLine(line)
+
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	if meterSymbol != "g,120" {
+		t.Errorf("Expected 'g', got '%s'", meterSymbol)
+	}
+
+	if meterId.Name() != "test" {
+		t.Errorf("Unexpected meterId: %v", meterId)
+	}
+
+	if value != "1" {
+		t.Errorf("Expected '1', got '%s'", value)
+	}
+}


### PR DESCRIPTION
Adding a protocol parser class to be used by other packages for testing emitted metrics.