### PR TITLE
writer: fixes race condition in MemoryWriter

### DIFF
--- a/spectator/meter/age_gauge_test.go
+++ b/spectator/meter/age_gauge_test.go
@@ -12,8 +12,8 @@ func TestAgeGauge_Set(t *testing.T) {
 	g.Set(100)
 
 	expected := "A:set:100"
-	if w.Lines[0] != expected {
-		t.Errorf("Expected line to be %s, got %s", expected, w.Lines[0])
+	if w.Lines()[0] != expected {
+		t.Errorf("Expected line to be %s, got %s", expected, w.Lines()[0])
 	}
 }
 
@@ -24,8 +24,8 @@ func TestAgeGauge_SetZero(t *testing.T) {
 	g.Set(0)
 
 	expected := "A:setZero:0"
-	if w.Lines[0] != expected {
-		t.Errorf("Expected line to be %s, got %s", expected, w.Lines[0])
+	if w.Lines()[0] != expected {
+		t.Errorf("Expected line to be %s, got %s", expected, w.Lines()[0])
 	}
 }
 
@@ -35,7 +35,7 @@ func TestAgeGauge_SetNegative(t *testing.T) {
 	g := NewAgeGauge(id, &w)
 	g.Set(-100)
 
-	if len(w.Lines) != 0 {
+	if len(w.Lines()) != 0 {
 		t.Error("Negative values should be ignored")
 	}
 }
@@ -49,7 +49,7 @@ func TestAgeGauge_SetMultipleValues(t *testing.T) {
 	g.Set(300)
 
 	expectedLines := []string{"A:setMultiple:100", "A:setMultiple:200", "A:setMultiple:300"}
-	for i, line := range w.Lines {
+	for i, line := range w.Lines() {
 		if line != expectedLines[i] {
 			t.Errorf("Expected line to be %s, got %s", expectedLines[i], line)
 		}
@@ -63,7 +63,7 @@ func TestAgeGauge_Now(t *testing.T) {
 	g.Now()
 
 	expected := "A:now:0"
-	if w.Lines[0] != expected {
-		t.Errorf("Expected line to be %s, got %s", expected, w.Lines[0])
+	if w.Lines()[0] != expected {
+		t.Errorf("Expected line to be %s, got %s", expected, w.Lines()[0])
 	}
 }

--- a/spectator/meter/counter_test.go
+++ b/spectator/meter/counter_test.go
@@ -13,8 +13,8 @@ func TestCounter_Increment(t *testing.T) {
 	c.Increment()
 
 	expected := "c:inc:1"
-	if w.Lines[0] != expected {
-		t.Error("Expected ", expected, " got ", w.Lines[0])
+	if w.Lines()[0] != expected {
+		t.Error("Expected ", expected, " got ", w.Lines()[0])
 	}
 }
 
@@ -26,12 +26,12 @@ func TestCounter_Add(t *testing.T) {
 	c.Add(4)
 
 	expected := "c:add:4"
-	if w.Lines[0] != expected {
-		t.Error("Expected ", expected, " got ", w.Lines[0])
+	if w.Lines()[0] != expected {
+		t.Error("Expected ", expected, " got ", w.Lines()[0])
 	}
 
 	c.Add(-1)
-	if len(w.Lines) != 1 {
+	if len(w.Lines()) != 1 {
 		t.Error("Negative deltas should be ignored")
 	}
 }
@@ -44,12 +44,12 @@ func TestCounter_AddFloat(t *testing.T) {
 	c.AddFloat(4.2)
 
 	expected := "c:addFloat:4.200000"
-	if w.Lines[0] != expected {
-		t.Error("Expected ", expected, " got ", w.Lines[0])
+	if w.Lines()[0] != expected {
+		t.Error("Expected ", expected, " got ", w.Lines()[0])
 	}
 
 	c.AddFloat(-0.1)
-	if len(w.Lines) != 1 {
+	if len(w.Lines()) != 1 {
 		t.Error("Negative deltas should be ignored")
 	}
 }

--- a/spectator/meter/dist_summary_test.go
+++ b/spectator/meter/dist_summary_test.go
@@ -12,8 +12,8 @@ func TestDistributionSummary_RecordPositiveValue(t *testing.T) {
 	ds.Record(100)
 
 	expected := "d:recordPositive:100"
-	if w.Lines[0] != expected {
-		t.Errorf("Expected line to be %s, got %s", expected, w.Lines[0])
+	if w.Lines()[0] != expected {
+		t.Errorf("Expected line to be %s, got %s", expected, w.Lines()[0])
 	}
 }
 
@@ -24,8 +24,8 @@ func TestDistributionSummary_RecordZeroValue(t *testing.T) {
 	ds.Record(0)
 
 	expected := "d:recordZero:0"
-	if w.Lines[0] != expected {
-		t.Errorf("Expected line to be %s, got %s", expected, w.Lines[0])
+	if w.Lines()[0] != expected {
+		t.Errorf("Expected line to be %s, got %s", expected, w.Lines()[0])
 	}
 }
 
@@ -35,8 +35,8 @@ func TestDistributionSummary_RecordNegativeValue(t *testing.T) {
 	ds := NewDistributionSummary(id, &w)
 	ds.Record(-100)
 
-	if len(w.Lines) != 0 {
-		t.Errorf("Expected no lines, got %d", len(w.Lines))
+	if len(w.Lines()) != 0 {
+		t.Errorf("Expected no lines, got %d", len(w.Lines()))
 	}
 }
 
@@ -49,7 +49,7 @@ func TestDistributionSummary_RecordMultipleValues(t *testing.T) {
 	ds.Record(300)
 
 	expectedLines := []string{"d:recordMultiple:100", "d:recordMultiple:200", "d:recordMultiple:300"}
-	for i, line := range w.Lines {
+	for i, line := range w.Lines() {
 		if line != expectedLines[i] {
 			t.Errorf("Expected line to be %s, got %s", expectedLines[i], line)
 		}

--- a/spectator/meter/gauge_test.go
+++ b/spectator/meter/gauge_test.go
@@ -14,8 +14,8 @@ func TestGauge_Set(t *testing.T) {
 	g.Set(100.1)
 
 	expected := "g:set:100.100000"
-	if w.Lines[0] != expected {
-		t.Errorf("Expected line to be %s, got %s", expected, w.Lines[0])
+	if w.Lines()[0] != expected {
+		t.Errorf("Expected line to be %s, got %s", expected, w.Lines()[0])
 	}
 }
 
@@ -26,8 +26,8 @@ func TestGauge_SetZero(t *testing.T) {
 	g.Set(0)
 
 	expected := "g:setZero:0.000000"
-	if w.Lines[0] != expected {
-		t.Errorf("Expected line to be %s, got %s", expected, w.Lines[0])
+	if w.Lines()[0] != expected {
+		t.Errorf("Expected line to be %s, got %s", expected, w.Lines()[0])
 	}
 }
 
@@ -38,8 +38,8 @@ func TestGauge_SetNegative(t *testing.T) {
 	g.Set(-100.1)
 
 	expected := "g:setNegative:-100.100000"
-	if w.Lines[0] != expected {
-		t.Errorf("Expected line to be %s, got %s", expected, w.Lines[0])
+	if w.Lines()[0] != expected {
+		t.Errorf("Expected line to be %s, got %s", expected, w.Lines()[0])
 	}
 }
 
@@ -52,7 +52,7 @@ func TestGauge_SetMultipleValues(t *testing.T) {
 	g.Set(300.3)
 
 	expectedLines := []string{"g:setMultiple:100.100000", "g:setMultiple:200.200000", "g:setMultiple:300.300000"}
-	for i, line := range w.Lines {
+	for i, line := range w.Lines() {
 		if line != expectedLines[i] {
 			t.Errorf("Expected line to be %s, got %s", expectedLines[i], line)
 		}
@@ -67,7 +67,7 @@ func TestGaugeWithTTL_Set(t *testing.T) {
 	g.Set(100.1)
 
 	expected := fmt.Sprintf("g,%d:setWithTTL:100.100000", int(ttl.Seconds()))
-	if w.Lines[0] != expected {
-		t.Errorf("Expected line to be %s, got %s", expected, w.Lines[0])
+	if w.Lines()[0] != expected {
+		t.Errorf("Expected line to be %s, got %s", expected, w.Lines()[0])
 	}
 }

--- a/spectator/meter/max_gauge_test.go
+++ b/spectator/meter/max_gauge_test.go
@@ -12,8 +12,8 @@ func TestMaxGauge_Set(t *testing.T) {
 	g.Set(100.1)
 
 	expected := "m:setMaxGauge:100.100000"
-	if w.Lines[0] != expected {
-		t.Errorf("Expected line to be %s, got %s", expected, w.Lines[0])
+	if w.Lines()[0] != expected {
+		t.Errorf("Expected line to be %s, got %s", expected, w.Lines()[0])
 	}
 }
 
@@ -24,8 +24,8 @@ func TestMaxGauge_SetZero(t *testing.T) {
 	g.Set(0)
 
 	expected := "m:setMaxGaugeZero:0.000000"
-	if w.Lines[0] != expected {
-		t.Errorf("Expected line to be %s, got %s", expected, w.Lines[0])
+	if w.Lines()[0] != expected {
+		t.Errorf("Expected line to be %s, got %s", expected, w.Lines()[0])
 	}
 }
 
@@ -36,8 +36,8 @@ func TestMaxGauge_SetNegative(t *testing.T) {
 	g.Set(-100.1)
 
 	expected := "m:setMaxGaugeNegative:-100.100000"
-	if w.Lines[0] != expected {
-		t.Errorf("Expected line to be %s, got %s", expected, w.Lines[0])
+	if w.Lines()[0] != expected {
+		t.Errorf("Expected line to be %s, got %s", expected, w.Lines()[0])
 	}
 }
 
@@ -50,7 +50,7 @@ func TestMaxGauge_SetMultipleValues(t *testing.T) {
 	g.Set(300.3)
 
 	expectedLines := []string{"m:setMaxGaugeMultiple:100.100000", "m:setMaxGaugeMultiple:200.200000", "m:setMaxGaugeMultiple:300.300000"}
-	for i, line := range w.Lines {
+	for i, line := range w.Lines() {
 		if line != expectedLines[i] {
 			t.Errorf("Expected line to be %s, got %s", expectedLines[i], line)
 		}

--- a/spectator/meter/monotonic_counter_test.go
+++ b/spectator/meter/monotonic_counter_test.go
@@ -13,7 +13,7 @@ func TestMonotonicCounter_Set(t *testing.T) {
 	c.Set(4)
 
 	expected := "C:set:4"
-	if w.Lines[0] != expected {
-		t.Error("Expected ", expected, " got ", w.Lines[0])
+	if w.Lines()[0] != expected {
+		t.Error("Expected ", expected, " got ", w.Lines()[0])
 	}
 }

--- a/spectator/meter/percentile_distsummary_test.go
+++ b/spectator/meter/percentile_distsummary_test.go
@@ -15,7 +15,7 @@ func TestPercentileDistributionSummary_Record(t *testing.T) {
 	ds.Record(3001)
 
 	expectedLines := []string{"D:recordPercentile:1000", "D:recordPercentile:2000", "D:recordPercentile:3000", "D:recordPercentile:3001"}
-	for i, line := range w.Lines {
+	for i, line := range w.Lines() {
 		if line != expectedLines[i] {
 			t.Errorf("Expected line to be %s, got %s", expectedLines[i], line)
 		}
@@ -29,8 +29,8 @@ func TestPercentileDistributionSummary_RecordZero(t *testing.T) {
 	ds.Record(0)
 
 	expected := "D:recordPercentileZero:0"
-	if w.Lines[0] != expected {
-		t.Errorf("Expected line to be %s, got %s", expected, w.Lines[0])
+	if w.Lines()[0] != expected {
+		t.Errorf("Expected line to be %s, got %s", expected, w.Lines()[0])
 	}
 }
 
@@ -40,8 +40,8 @@ func TestPercentileDistributionSummary_RecordNegative(t *testing.T) {
 	ds := NewPercentileDistributionSummary(id, &w)
 	ds.Record(-100)
 
-	if len(w.Lines) != 0 {
-		t.Errorf("Expected no lines to be written, got %d", len(w.Lines))
+	if len(w.Lines()) != 0 {
+		t.Errorf("Expected no lines to be written, got %d", len(w.Lines()))
 	}
 }
 
@@ -54,7 +54,7 @@ func TestPercentileDistributionSummary_RecordMultipleValues(t *testing.T) {
 	ds.Record(300)
 
 	expectedLines := []string{"D:recordPercentileMultiple:100", "D:recordPercentileMultiple:200", "D:recordPercentileMultiple:300"}
-	for i, line := range w.Lines {
+	for i, line := range w.Lines() {
 		if line != expectedLines[i] {
 			t.Errorf("Expected line to be %s, got %s", expectedLines[i], line)
 		}

--- a/spectator/meter/percentile_timer_test.go
+++ b/spectator/meter/percentile_timer_test.go
@@ -21,7 +21,7 @@ func TestPercentileTimer_Record(t *testing.T) {
 		"T:recordPercentileTimer:3.000000",
 		"T:recordPercentileTimer:3.001000",
 	}
-	for i, line := range w.Lines {
+	for i, line := range w.Lines() {
 		if line != expectedLines[i] {
 			t.Errorf("Expected line to be %s, got %s", expectedLines[i], line)
 		}
@@ -35,8 +35,8 @@ func TestPercentileTimer_RecordZero(t *testing.T) {
 	pt.Record(0)
 
 	expected := "T:recordPercentileTimerZero:0.000000"
-	if w.Lines[0] != expected {
-		t.Errorf("Expected line to be %s, got %s", expected, w.Lines[0])
+	if w.Lines()[0] != expected {
+		t.Errorf("Expected line to be %s, got %s", expected, w.Lines()[0])
 	}
 }
 
@@ -46,7 +46,7 @@ func TestPercentileTimer_RecordNegative(t *testing.T) {
 	pt := NewPercentileTimer(id, &w)
 	pt.Record(-100 * time.Millisecond)
 
-	if len(w.Lines) != 0 {
+	if len(w.Lines()) != 0 {
 		t.Error("Negative durations should be ignored")
 	}
 }
@@ -64,7 +64,7 @@ func TestPercentileTimer_RecordMultipleValues(t *testing.T) {
 		"T:recordPercentileTimerMultiple:0.200000",
 		"T:recordPercentileTimerMultiple:0.300000",
 	}
-	for i, line := range w.Lines {
+	for i, line := range w.Lines() {
 		if line != expectedLines[i] {
 			t.Errorf("Expected line to be %s, got %s", expectedLines[i], line)
 		}

--- a/spectator/meter/timer_test.go
+++ b/spectator/meter/timer_test.go
@@ -16,7 +16,7 @@ func TestTimer_Record(t *testing.T) {
 	timer.Record(3001 * time.Millisecond)
 
 	expectedLines := []string{"t:recordTimer:1.000000", "t:recordTimer:2.000000", "t:recordTimer:3.000000", "t:recordTimer:3.001000"}
-	for i, line := range w.Lines {
+	for i, line := range w.Lines() {
 		if line != expectedLines[i] {
 			t.Errorf("Expected line to be %s, got %s", expectedLines[i], line)
 		}
@@ -30,8 +30,8 @@ func TestTimer_RecordZero(t *testing.T) {
 	timer.Record(0)
 
 	expected := "t:recordTimerZero:0.000000"
-	if w.Lines[0] != expected {
-		t.Errorf("Expected line to be %s, got %s", expected, w.Lines[0])
+	if w.Lines()[0] != expected {
+		t.Errorf("Expected line to be %s, got %s", expected, w.Lines()[0])
 	}
 }
 
@@ -41,7 +41,7 @@ func TestTimer_RecordNegative(t *testing.T) {
 	timer := NewTimer(id, &w)
 	timer.Record(-100 * time.Millisecond)
 
-	if len(w.Lines) != 0 {
+	if len(w.Lines()) != 0 {
 		t.Error("Negative durations should be ignored")
 	}
 }
@@ -59,7 +59,7 @@ func TestTimer_RecordMultipleValues(t *testing.T) {
 		"t:recordTimerMultiple:0.200000",
 		"t:recordTimerMultiple:0.300000",
 	}
-	for i, line := range w.Lines {
+	for i, line := range w.Lines() {
 		if line != expectedLines[i] {
 			t.Errorf("Expected line to be %s, got %s", expectedLines[i], line)
 		}

--- a/spectator/registry_test.go
+++ b/spectator/registry_test.go
@@ -15,8 +15,8 @@ func TestRegistryWithMemoryWriter_Counter(t *testing.T) {
 	counter := r.Counter("test_counter", nil)
 	counter.Increment()
 	expected := "c:test_counter:1"
-	if len(mw.Lines) != 1 || mw.Lines[0] != expected {
-		t.Errorf("Expected '%s', got '%s'", expected, mw.Lines[0])
+	if len(mw.Lines()) != 1 || mw.Lines()[0] != expected {
+		t.Errorf("Expected '%s', got '%s'", expected, mw.Lines()[0])
 	}
 }
 
@@ -27,8 +27,8 @@ func TestRegistryWithMemoryWriter_MonotonicCounter(t *testing.T) {
 	counter := r.MonotonicCounter("test_monotonic_counter", nil)
 	counter.Set(1)
 	expected := "C:test_monotonic_counter:1"
-	if len(mw.Lines) != 1 || mw.Lines[0] != expected {
-		t.Errorf("Expected '%s', got '%s'", expected, mw.Lines[0])
+	if len(mw.Lines()) != 1 || mw.Lines()[0] != expected {
+		t.Errorf("Expected '%s', got '%s'", expected, mw.Lines()[0])
 	}
 }
 
@@ -39,8 +39,8 @@ func TestRegistryWithMemoryWriter_Timer(t *testing.T) {
 	timer := r.Timer("test_timer", nil)
 	timer.Record(100 * time.Millisecond)
 	expected := "t:test_timer:0.100000"
-	if len(mw.Lines) != 1 || mw.Lines[0] != expected {
-		t.Errorf("Expected '%s', got '%s'", expected, mw.Lines[0])
+	if len(mw.Lines()) != 1 || mw.Lines()[0] != expected {
+		t.Errorf("Expected '%s', got '%s'", expected, mw.Lines()[0])
 	}
 }
 
@@ -51,8 +51,8 @@ func TestRegistryWithMemoryWriter_Gauge(t *testing.T) {
 	gauge := r.Gauge("test_gauge", nil)
 	gauge.Set(100)
 	expected := "g:test_gauge:100.000000"
-	if len(mw.Lines) != 1 || mw.Lines[0] != expected {
-		t.Errorf("Expected '%s', got '%s'", expected, mw.Lines[0])
+	if len(mw.Lines()) != 1 || mw.Lines()[0] != expected {
+		t.Errorf("Expected '%s', got '%s'", expected, mw.Lines()[0])
 	}
 }
 
@@ -65,8 +65,8 @@ func TestRegistryWithMemoryWriter_GaugeWithTTL(t *testing.T) {
 	gauge.Set(100.1)
 
 	expected := fmt.Sprintf("g,%d:test_gauge_ttl:100.100000", int(ttl.Seconds()))
-	if len(mw.Lines) != 1 || mw.Lines[0] != expected {
-		t.Errorf("Expected '%s', got '%s'", expected, mw.Lines[0])
+	if len(mw.Lines()) != 1 || mw.Lines()[0] != expected {
+		t.Errorf("Expected '%s', got '%s'", expected, mw.Lines()[0])
 	}
 }
 
@@ -77,8 +77,8 @@ func TestRegistryWithMemoryWriter_AgeGauge(t *testing.T) {
 	ageGauge := r.AgeGauge("test_age_gauge", nil)
 	ageGauge.Set(100)
 	expected := "A:test_age_gauge:100"
-	if len(mw.Lines) != 1 || mw.Lines[0] != expected {
-		t.Errorf("Expected '%s', got '%s'", expected, mw.Lines[0])
+	if len(mw.Lines()) != 1 || mw.Lines()[0] != expected {
+		t.Errorf("Expected '%s', got '%s'", expected, mw.Lines()[0])
 	}
 }
 
@@ -89,8 +89,8 @@ func TestRegistryWithMemoryWriter_MaxGauge(t *testing.T) {
 	maxGauge := r.MaxGauge("test_maxgauge", nil)
 	maxGauge.Set(200)
 	expected := "m:test_maxgauge:200.000000"
-	if len(mw.Lines) != 1 || mw.Lines[0] != expected {
-		t.Errorf("Expected '%s', got '%s'", expected, mw.Lines[0])
+	if len(mw.Lines()) != 1 || mw.Lines()[0] != expected {
+		t.Errorf("Expected '%s', got '%s'", expected, mw.Lines()[0])
 	}
 }
 
@@ -101,8 +101,8 @@ func TestRegistryWithMemoryWriter_DistributionSummary(t *testing.T) {
 	distSummary := r.DistributionSummary("test_distributionsummary", nil)
 	distSummary.Record(300)
 	expected := "d:test_distributionsummary:300"
-	if len(mw.Lines) != 1 || mw.Lines[0] != expected {
-		t.Errorf("Expected '%s', got '%s'", expected, mw.Lines[0])
+	if len(mw.Lines()) != 1 || mw.Lines()[0] != expected {
+		t.Errorf("Expected '%s', got '%s'", expected, mw.Lines()[0])
 	}
 }
 
@@ -113,8 +113,8 @@ func TestRegistryWithMemoryWriter_PercentileDistributionSummary(t *testing.T) {
 	percentileDistSummary := r.PercentileDistributionSummary("test_percentiledistributionsummary", nil)
 	percentileDistSummary.Record(400)
 	expected := "D:test_percentiledistributionsummary:400"
-	if len(mw.Lines) != 1 || mw.Lines[0] != expected {
-		t.Errorf("Expected '%s', got '%s'", expected, mw.Lines[0])
+	if len(mw.Lines()) != 1 || mw.Lines()[0] != expected {
+		t.Errorf("Expected '%s', got '%s'", expected, mw.Lines()[0])
 	}
 }
 
@@ -125,8 +125,8 @@ func TestRegistryWithMemoryWriter_PercentileTimer(t *testing.T) {
 	percentileTimer := r.PercentileTimer("test_percentiletimer", nil)
 	percentileTimer.Record(500 * time.Millisecond)
 	expected := "T:test_percentiletimer:0.500000"
-	if len(mw.Lines) != 1 || mw.Lines[0] != expected {
-		t.Errorf("Expected '%s', got '%s'", expected, mw.Lines[0])
+	if len(mw.Lines()) != 1 || mw.Lines()[0] != expected {
+		t.Errorf("Expected '%s', got '%s'", expected, mw.Lines()[0])
 	}
 }
 


### PR DESCRIPTION
There is a data race if one tries to hit the MemoryWriter from multiple threads. This diff adds:

1. A test that exposes this issue
2. An RWMutex that protects access to the underlying slice in MemoryWriter
3. A Method `MemoryWriter.Lines` that can be used to safely access the lines written to the writer.