### PR TITLE
fix uds config support

### DIFF
--- a/spectator/writer/writer.go
+++ b/spectator/writer/writer.go
@@ -79,7 +79,8 @@ func IsValidOutputLocation(output string) bool {
 		output == "stdout" ||
 		output == "stderr" ||
 		strings.HasPrefix(output, "file://") ||
-		strings.HasPrefix(output, "udp://")
+		strings.HasPrefix(output, "udp://") ||
+		strings.HasPrefix(output, "unix://")
 }
 
 // NewWriter Create a new writer based on the GetLocation string provided

--- a/spectator/writer/writer_test.go
+++ b/spectator/writer/writer_test.go
@@ -19,6 +19,7 @@ func TestValidOutputLocation(t *testing.T) {
 		{"stderr", true},
 		{"file://testfile.txt", true},
 		{"udp://localhost:1234", true},
+		{"unix:///tmp/socket.sock", true},
 		{"invalid", false},
 	}
 
@@ -41,6 +42,7 @@ func TestNewWriter(t *testing.T) {
 		{"stderr", "*writer.StderrWriter"},
 		{"file://testfile.txt", "*writer.FileWriter"},
 		{"udp://localhost:5000", "*writer.UdpWriter"},
+		{"unix:///tmp/socket.sock", "*writer.UnixgramWriter"},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Fix allowing `unix://` locations in the output config so UDS can be used.

Without this change, the config location validation process rejects the `unix://<path>` values with a `invalid spectatord location`.