### PR TITLE
remove WithDefaultStat and WithStat methods

### DIFF
--- a/spectator/meter/id.go
+++ b/spectator/meter/id.go
@@ -107,25 +107,6 @@ func (id *Id) WithTag(key string, value string) *Id {
 	return NewId(id.name, newTags)
 }
 
-// WithStat is id.WithTag("statistic", stat). See that method's documentation
-// for more info.
-func (id *Id) WithStat(stat string) *Id {
-	return id.WithTag("statistic", stat)
-}
-
-// WithDefaultStat is effectively the WithStat() method, except it only creates
-// the deep copy if the "statistic" tag is not set or is set to empty string. If
-// the "statistic" tag is already present, the *Id is returned without being
-// copied.
-func (id *Id) WithDefaultStat(stat string) *Id {
-	s := id.tags["statistic"]
-	if s == "" {
-		return id.WithTag("statistic", stat)
-	} else {
-		return id
-	}
-}
-
 func (id *Id) String() string {
 	return fmt.Sprintf("Id{name=%s,tags=%v}", id.name, id.tags)
 }

--- a/spectator/meter/id_test.go
+++ b/spectator/meter/id_test.go
@@ -86,16 +86,6 @@ func TestId_Accessors(t *testing.T) {
 	}
 }
 
-func TestId_WithDefaultStat(t *testing.T) {
-	id1 := NewId("c", map[string]string{"statistic": "baz"})
-	id2 := id1.WithDefaultStat("counter")
-
-	if id2.Tags()["statistic"] != "baz" {
-		t.Errorf("Default stat should reuse the existing statistic. Got %s instead of baz",
-			id2.Tags()["statistic"])
-	}
-}
-
 func TestId_WithTags(t *testing.T) {
 	id1 := NewId("c", map[string]string{"statistic": "baz", "a": "b"})
 	id2 := id1.WithTags(map[string]string{"statistic": "foo", "k": "v"})
@@ -106,14 +96,6 @@ func TestId_WithTags(t *testing.T) {
 
 	if !reflect.DeepEqual(expected, id2.Tags()) {
 		t.Errorf("Expected %v, got %v tags", expected, id2.Tags())
-	}
-}
-
-func TestId_WithStat(t *testing.T) {
-	id1 := NewId("c", nil)
-	id2 := id1.WithStat("stuff")
-	if id2.String() != "Id{name=c,tags=map[statistic:stuff]}" {
-		t.Errorf("Got %s", id2.String())
 	}
 }
 


### PR DESCRIPTION
These are leftover from the thick client implementation. SpectatorD is now responsible for setting the `statistic` tag, based upon the meter type specified in the protocol line.