### PR TITLE
writer: allows `unix` location in config

### DIFF
--- a/spectator/writer/writer.go
+++ b/spectator/writer/writer.go
@@ -78,6 +78,7 @@ func IsValidOutputLocation(output string) bool {
 		output == "memory" ||
 		output == "stdout" ||
 		output == "stderr" ||
+		output == "unix" ||
 		strings.HasPrefix(output, "file://") ||
 		strings.HasPrefix(output, "udp://") ||
 		strings.HasPrefix(output, "unix://")

--- a/spectator/writer/writer_test.go
+++ b/spectator/writer/writer_test.go
@@ -17,6 +17,7 @@ func TestValidOutputLocation(t *testing.T) {
 		{"memory", true},
 		{"stdout", true},
 		{"stderr", true},
+		{"unix", true},
 		{"file://testfile.txt", true},
 		{"udp://localhost:1234", true},
 		{"unix:///tmp/socket.sock", true},


### PR DESCRIPTION
PR #105 allowed the use of the `unix` as a shorthand for spectatord's default unix socket path. This diff updates the config validation logic so that folks can pass that value in.