### PR TITLE
make UnixgramWriter resilient to connection drops

### DIFF
--- a/spectator/config.go
+++ b/spectator/config.go
@@ -19,22 +19,21 @@ type Config struct {
 //
 // Possible values for location are:
 //
+//   - `""`     - Empty string will default to `udp`.
 //   - `none`   - Configure a no-op writer that does nothing. Can be used to disable metrics collection.
 //   - `memory` - Write metrics to memory. Useful for testing.
 //   - `stderr` - Write metrics to standard error.
 //   - `stdout` - Write metrics to standard output.
-//   - `unix`   - Write metrics to the default Unix Domain Socket. Useful for high-volume scenarios.
+//   - `udp`    - Write metrics to the default spectatord UDP port. This is the default value.
+//   - `unix`   - Write metrics to the default spectatord Unix Domain Socket. Useful for high-volume scenarios.
 //   - `file:///path/to/file`   - Write metrics to a file.
 //   - `udp://host:port`        - Write metrics to a UDP socket.
 //   - `unix:///path/to/socket` - Write metrics to a Unix Domain Socket.
 //
-// If a location is not provided, or it is an empty string, then the default location of `udp://127.0.0.1:1234` will
-// be used.
-//
 // The output location can be overridden by configuring an environment variable SPECTATOR_OUTPUT_LOCATION
 // with one of the values listed above. Overriding the output location may be useful for integration testing.
 func NewConfig(
-	location string, // defaults to `udp://127.0.0.1:1234`
+	location string, // defaults to `udp`
 	commonTags map[string]string, // defaults to empty map
 	log logger.Logger, // defaults to default logger
 ) (*Config, error) {
@@ -94,7 +93,7 @@ func calculateLocation(location string) (string, error) {
 	}
 
 	if location == "" { // use the default, if there is no location or override
-		location = "udp://127.0.0.1:1234"
+		location = "udp"
 	}
 
 	return location, nil

--- a/spectator/config_test.go
+++ b/spectator/config_test.go
@@ -111,7 +111,7 @@ func TestGetLocation_DefaultValue(t *testing.T) {
 	}
 
 	result := cfg.location
-	expected := "udp://127.0.0.1:1234"
+	expected := "udp"
 	if result != expected {
 		t.Errorf("Expected '%s', got '%s'", expected, result)
 	}

--- a/spectator/writer/unixgram_writer.go
+++ b/spectator/writer/unixgram_writer.go
@@ -1,12 +1,13 @@
 package writer
 
 import (
-	"fmt"
 	"github.com/Netflix/spectator-go/v2/spectator/logger"
 	"net"
+	"strings"
 )
 
 type UnixgramWriter struct {
+	addr   *net.UnixAddr
 	conn   *net.UnixConn
 	logger logger.Logger
 }
@@ -15,17 +16,50 @@ func NewUnixgramWriter(path string, logger logger.Logger) (*UnixgramWriter, erro
 	addr := &net.UnixAddr{Name: path, Net: "unixgram"}
 	conn, err := net.DialUnix("unixgram", nil, addr)
 	if err != nil {
-		return nil, fmt.Errorf("failed to dial unix socket: %v", err)
+		logger.Errorf("failed to dial unix socket: %v", err)
+		conn = nil
 	}
 
-	return &UnixgramWriter{conn, logger}, nil
+	return &UnixgramWriter{addr, conn, logger}, nil
 }
 
+// If anything disturbs access to the unix socket, such as a spectatord process restart (or another
+// unknown condition), then all future writes to the unix socket will fail with a "transport endpoint
+// is not connected" error.
+//
+// This means that the UdpWriter is generally more resilient across more operating conditions than the
+// UnixgramWriter. The UdpWriter does not continue to fail once it encounters a single failure to write,
+// it resumes writing when the port is available again, and it does not require any special connection
+// handling.
+//
+// The addition of reconnect logic to the UnixgramWriter mitigates ongoing issues with unix socket write
+// errors. Some packet delivery failure will occur until it can reconnect. With the reconnect logic in
+// place, the initialization is now more resilient if the unix socket is not available at program start.
 func (u *UnixgramWriter) Write(line string) {
 	u.logger.Debugf("Sending line: %s", line)
 
-	if _, err := u.conn.Write([]byte(line)); err != nil {
-		fmt.Printf("failed to write to unix socket: %v\n", err)
+	if u.conn != nil {
+		if _, err := u.conn.Write([]byte(line)); err != nil {
+			u.logger.Errorf("failed to write to unix socket: %v\n", err)
+
+			if strings.Contains(err.Error(), "transport endpoint is not connected") {
+				u.logger.Infof("close unix socket")
+				err := u.conn.Close()
+				if err != nil {
+					u.logger.Errorf("failed to close unix socket: %v\n", err)
+				}
+				u.conn = nil
+			}
+		}
+	} else {
+		u.logger.Infof("re-dial unix socket")
+
+		conn, err := net.DialUnix("unixgram", nil, u.addr)
+		if err != nil {
+			u.logger.Errorf("failed to dial unix socket: %v", err)
+		} else {
+			u.conn = conn
+		}
 	}
 }
 

--- a/spectator/writer/writer.go
+++ b/spectator/writer/writer.go
@@ -99,7 +99,14 @@ func NewWriter(outputLocation string, logger logger.Logger) (Writer, error) {
 	case outputLocation == "stderr":
 		logger.Infof("Initializing StderrWriter")
 		return &StderrWriter{}, nil
+	case outputLocation == "udp":
+		// default udp port for spectatord
+		outputLocation = "udp://127.0.0.1:1234"
+		logger.Infof("Initializing UdpWriter with address %s", outputLocation)
+		address := strings.TrimPrefix(outputLocation, "udp://")
+		return NewUdpWriter(address, logger)
 	case outputLocation == "unix":
+		// default unix domain socket for spectatord
 		outputLocation = "unix:///run/spectatord/spectatord.unix"
 		logger.Infof("Initializing UnixgramWriter with path %s", outputLocation)
 		path := strings.TrimPrefix(outputLocation, "unix://")


### PR DESCRIPTION
We experienced an issue where something was disrupting communication to the `spectatord` unix socket, which caused the connection to fail every write after that point. The `UnixgramWriter` was originally configured such that it would panic if it could not establish an initial connection with the unix socket, so `spectatord` would start, something would disturb the connection, and then no more metrics would be delivered and the logs would be spammed with errors.

The two main differences between the `UdpWriter` and the `UnixgramWriter`, are (1) the `UdpWriter` is more resilient under more conditions, with less logic, and (2) the unix socket can provide higher throughput.

This change adds resilience to the `UnixgramWriter`, so that initialization is resilient to the absence of the unix socket, and any disruption of the connection will cause it to close the connection, and reconnect on subsequent writes. In order to maintain simplicity and statelessness, some packet loss will occur during a connection disruption, but it will resume as soon as the unix socket is available again. As long as metrics are delivered frequently, more often than once per minute, then small losses such as this may not be observed.

These changes were tested on a live system, while restarting the `spectatord` process.

Additionally, clean up handling of the default writer.