### PR TITLE
restore the Spectator Histogram buckets file as an assist for users who

### DIFF
--- a/spectator/meter/buckets.go
+++ b/spectator/meter/buckets.go
@@ -1,0 +1,107 @@
+package meter
+
+import (
+	"math"
+	"math/bits"
+)
+
+var (
+	bucketValues  []int64
+	powerOf4Index []int
+)
+
+func init() {
+	const DIGITS uint8 = 2
+	bucketValues = append(bucketValues, 1, 2, 3)
+	powerOf4Index = append(powerOf4Index, 0)
+
+	for exp := DIGITS; exp < 64; exp += DIGITS {
+		var current int64 = 1 << exp
+		delta := current / 3
+		next := (current << DIGITS) - delta
+		powerOf4Index = append(powerOf4Index, len(bucketValues))
+
+		for ; current < next; current += delta {
+			bucketValues = append(bucketValues, current)
+		}
+	}
+
+	bucketValues = append(bucketValues, math.MaxInt64)
+}
+
+// PercentileBucketsLength returns the lengths of the package local bucketValues
+// variable, to give an idea of how many buckets exist.
+func PercentileBucketsLength() int {
+	return len(bucketValues)
+}
+
+// PercentileBucketsIndex calculates which bucket handles that specific value.
+func PercentileBucketsIndex(v int64) int {
+	if v <= 0 {
+		return 0
+	} else if v <= 15 {
+		return int(v)
+	} else {
+		lz := bits.LeadingZeros64(uint64(v))
+		shift := uint(64 - lz - 1)
+		prevPowerOf2 := (v >> shift) << shift
+		prevPowerOf4 := prevPowerOf2
+		if shift%2 != 0 {
+			shift--
+			prevPowerOf4 = prevPowerOf2 >> 1
+		}
+
+		base := prevPowerOf4
+		delta := base / 3
+		offset := int((v - base) / delta)
+		pos := offset + powerOf4Index[shift/2]
+		if pos >= len(bucketValues)-1 {
+			return len(bucketValues) - 1
+		}
+		return pos + 1
+	}
+}
+
+// PercentileBucketsBucket returns the bucketValue for the specific value.
+func PercentileBucketsBucket(v int64) int64 {
+	return bucketValues[PercentileBucketsIndex(v)]
+}
+
+// PercentileBucketsPercentiles takes the counts, and desired percentiles, and
+// generates the proper results.
+func PercentileBucketsPercentiles(counts []int64, pcts []float64) []float64 {
+	results := make([]float64, len(pcts))
+	total := float64(0)
+	for _, c := range counts {
+		total += float64(c)
+	}
+	pctIndex := 0
+	prev := int64(0)
+	prevP := 0.0
+	prevB := int64(0)
+	for i, nextB := range bucketValues {
+		next := prev + counts[i]
+		nextP := 100 * float64(next) / total
+		for ; pctIndex < len(pcts) && nextP >= pcts[pctIndex]; pctIndex++ {
+			f := (pcts[pctIndex] - prevP) / (nextP - prevP)
+			results[pctIndex] = f*float64(nextB-prevB) + float64(prevB)
+		}
+		if pctIndex >= len(pcts) {
+			break
+		}
+		prev = next
+		prevP = nextP
+		prevB = nextB
+	}
+
+	return results
+}
+
+// PercentileBucketsPercentile takes the counts, and returns the requested
+// percentile value based on the counts.
+func PercentileBucketsPercentile(counts []int64, pct float64) float64 {
+	pcts := make([]float64, 1)
+	pcts[0] = pct
+	results := PercentileBucketsPercentiles(counts, pcts)
+	return results[0]
+}

--- a/spectator/meter/buckets_test.go
+++ b/spectator/meter/buckets_test.go
@@ -1,0 +1,106 @@
+package meter
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+)
+
+func TestPercentileBucketsLength(t *testing.T) {
+	if PercentileBucketsLength() != 276 {
+		t.Errorf("Expecting 276 percentile buckets. Got %d", PercentileBucketsLength())
+	}
+}
+
+func assertIndex(t *testing.T, v int64, expected int) {
+	idx := PercentileBucketsIndex(v)
+	if idx != expected {
+		t.Errorf("PercentileBucketsIndex(%d) = %d, expected %d", v, idx, expected)
+	}
+}
+
+func TestPercentileBucketsIndex(t *testing.T) {
+	assertIndex(t, -1, 0)
+	for i := 0; i < 5; i++ {
+		assertIndex(t, int64(i), i)
+	}
+
+	assertIndex(t, 21, 16)
+	assertIndex(t, 31, 18)
+	assertIndex(t, 87, 25)
+	assertIndex(t, 1020, 41)
+	assertIndex(t, 10000, 55)
+	assertIndex(t, 100000, 70)
+	assertIndex(t, 1000*1000, 86)
+	assertIndex(t, 10*1000*1000, 100)
+	assertIndex(t, 100*1000*1000, 115)
+	assertIndex(t, 1000*1000*1000, 131)
+	assertIndex(t, 10*1000*1000*1000, 144)
+	assertIndex(t, 100*1000*1000*1000, 160)
+	assertIndex(t, 1000*1000*1000*1000, 175)
+}
+
+func getNumber() int64 {
+	return rand.Int63()
+}
+
+func TestPercentileBucketsBucket(t *testing.T) {
+	for i := 0; i < 10000; i++ {
+		n := getNumber()
+		b := PercentileBucketsBucket(n)
+		if n > b {
+			t.Errorf("Expecting %d <= %d", n, b)
+		}
+	}
+}
+
+func assertPercentiles(t *testing.T, results []float64, expected []float64) {
+	if len(results) != len(expected) {
+		t.Errorf("Expected %d results, got %d instead",
+			len(expected), len(results))
+	}
+
+	for i, e := range expected {
+		threshold := e * 0.1
+		if math.Abs(e-results[i]) > threshold {
+			t.Errorf("Percentile at index %d: Got %.1f - Expected %.1f",
+				i, results[i], e)
+		}
+	}
+}
+
+func TestPercentileBucketsPercentiles(t *testing.T) {
+	counts := make([]int64, PercentileBucketsLength())
+	for i := 0; i < 100000; i++ {
+		counts[PercentileBucketsIndex(int64(i))]++
+	}
+	var pcts []float64
+	pcts = append(pcts,
+		0.0, 25.0, 50.0, 75.0, 90.0, 95.0, 98.0, 99.0, 99.5, 100.0)
+
+	results := PercentileBucketsPercentiles(counts, pcts)
+	var expected []float64
+	expected = append(expected,
+		0.0, 25e3, 50e3, 75e3, 90e3, 95e3, 98e3, 99e3, 99.5e3, 100e3)
+	assertPercentiles(t, results, expected)
+}
+
+func TestPercentileBucketsPercentile(t *testing.T) {
+	counts := make([]int64, PercentileBucketsLength())
+	for i := 0; i < 100000; i++ {
+		counts[PercentileBucketsIndex(int64(i))]++
+	}
+
+	var pcts []float64
+	pcts = append(pcts,
+		0.0, 25.0, 50.0, 75.0, 90.0, 95.0, 98.0, 99.0, 99.5, 100.0)
+	for _, pct := range pcts {
+		expected := pct * 1e3
+		threshold := 0.1*expected + 1e-12
+		p := PercentileBucketsPercentile(counts, pct)
+		if math.Abs(expected-p) > threshold {
+			t.Errorf("Failed to compute %.1f percentile: %.1f != %.1f",
+				pct, p, expected)
+		}
+	}
+}


### PR DESCRIPTION
need to convert Prometheus classic histograms to Atlas. Removed the method to create counters as we only want the bucket definitions and `PercentileBucketsIndex` method to prevent users from computing the wrong buckets.