### PR TITLE
add LineBuffer to UdpWriter and UnixgramWriter with configurable buffering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .idea/
-
+CLAUDE.md

--- a/spectator/config.go
+++ b/spectator/config.go
@@ -12,6 +12,7 @@ type Config struct {
 	location        string
 	extraCommonTags map[string]string
 	log             logger.Logger
+	bufferSize      int
 }
 
 // NewConfig creates a new configuration with the provided location, extra common tags, and logger. All fields are
@@ -37,6 +38,15 @@ func NewConfig(
 	extraCommonTags map[string]string, // defaults to empty map
 	log logger.Logger, // defaults to default logger
 ) (*Config, error) {
+	return NewConfigWithBuffer(location, extraCommonTags, log, 0)
+}
+
+func NewConfigWithBuffer(
+	location string, // defaults to `udp`
+	extraCommonTags map[string]string, // defaults to empty map
+	log logger.Logger, // defaults to default logger
+	bufferSize int, // defaults to 0 (disabled)
+) (*Config, error) {
 	location, err := calculateLocation(location)
 	if err != nil {
 		return nil, err
@@ -50,6 +60,7 @@ func NewConfig(
 		location:        location,
 		extraCommonTags: mergedTags,
 		log:             lg,
+		bufferSize:      bufferSize,
 	}, nil
 }
 

--- a/spectator/registry.go
+++ b/spectator/registry.go
@@ -69,7 +69,7 @@ func NewRegistry(config *Config) (Registry, error) {
 		config, _ = NewConfig("", nil, nil)
 	}
 
-	newWriter, err := writer.NewWriter(config.location, config.log)
+	newWriter, err := writer.NewWriterWithBuffer(config.location, config.log, config.bufferSize)
 	if err != nil {
 		return nil, err
 	}
@@ -94,7 +94,7 @@ func (r *spectatordRegistry) GetLogger() logger.Logger {
 func (r *spectatordRegistry) NewId(name string, tags map[string]string) *meter.Id {
 	newId := meter.NewId(name, tags)
 
-	if r.config.extraCommonTags != nil && len(r.config.extraCommonTags) > 0 {
+	if len(r.config.extraCommonTags) > 0 {
 		newId = newId.WithTags(r.config.extraCommonTags)
 	}
 

--- a/spectator/writer/line_buffer.go
+++ b/spectator/writer/line_buffer.go
@@ -1,0 +1,118 @@
+package writer
+
+import (
+	"github.com/Netflix/spectator-go/v2/spectator/logger"
+	"strings"
+	"sync"
+	"time"
+)
+
+type LineBuffer struct {
+	writer       Writer
+	bufferSize   int
+	flushTimeout time.Duration
+	logger       logger.Logger
+	
+	mu         sync.Mutex
+	buffer     strings.Builder
+	lineCount  int
+	lastFlush  time.Time
+	flushTimer *time.Timer
+	closed     bool
+}
+
+func NewLineBuffer(writer Writer, bufferSize int, logger logger.Logger, timeoutOptional ...time.Duration) *LineBuffer {
+	timeout := 5 * time.Second
+	if len(timeoutOptional) > 0 {
+		timeout = timeoutOptional[0]
+	}
+
+	lb := &LineBuffer{
+		writer:       writer,
+		bufferSize:   bufferSize,
+		flushTimeout: timeout,
+		logger:       logger,
+		lastFlush:    time.Now(),
+	}
+
+	lb.startFlushTimer()
+
+	return lb
+}
+
+func (lb *LineBuffer) Write(line string) {
+	if lb.bufferSize <= 0 {
+		lb.writer.Write(line)
+		return
+	}
+	
+	lb.mu.Lock()
+	defer lb.mu.Unlock()
+	
+	if lb.closed {
+		return
+	}
+	
+	if lb.buffer.Len() > 0 {
+		lb.buffer.WriteString("\n")
+	}
+	lb.buffer.WriteString(line)
+	lb.lineCount++
+	
+	if lb.buffer.Len() >= lb.bufferSize {
+		lb.flushLocked()
+	}
+}
+
+func (lb *LineBuffer) Close() error {
+	if lb.bufferSize <= 0 {
+		return lb.writer.Close()
+	}
+	
+	lb.mu.Lock()
+	defer lb.mu.Unlock()
+	
+	if lb.closed {
+		return nil
+	}
+	
+	lb.closed = true
+	
+	if lb.flushTimer != nil {
+		lb.flushTimer.Stop()
+	}
+	
+	lb.flushLocked()
+	return lb.writer.Close()
+}
+
+func (lb *LineBuffer) startFlushTimer() {
+	lb.flushTimer = time.AfterFunc(lb.flushTimeout, lb.timerFlush)
+}
+
+func (lb *LineBuffer) timerFlush() {
+	lb.mu.Lock()
+	defer lb.mu.Unlock()
+	
+	if lb.closed {
+		return
+	}
+	
+	if time.Since(lb.lastFlush) >= lb.flushTimeout {
+		lb.flushLocked()
+	}
+	
+	lb.startFlushTimer()
+}
+
+func (lb *LineBuffer) flushLocked() {
+	if lb.buffer.Len() == 0 {
+		return
+	}
+	
+	lb.logger.Debugf("Flushing buffer with %d lines (%d bytes)", lb.lineCount, lb.buffer.Len())
+	lb.writer.Write(lb.buffer.String())
+	lb.buffer.Reset()
+	lb.lineCount = 0
+	lb.lastFlush = time.Now()
+}

--- a/spectator/writer/line_buffer_test.go
+++ b/spectator/writer/line_buffer_test.go
@@ -1,0 +1,115 @@
+package writer
+
+import (
+	"github.com/Netflix/spectator-go/v2/spectator/logger"
+	"testing"
+	"time"
+)
+
+func TestLineBuffer_DisabledWhenBufferSizeZero(t *testing.T) {
+	memWriter := &MemoryWriter{}
+	buffer := NewLineBuffer(memWriter, 0, logger.NewDefaultLogger())
+	
+	buffer.Write("line1")
+	buffer.Write("line2")
+	
+	lines := memWriter.Lines()
+	if len(lines) != 2 {
+		t.Errorf("Expected 2 lines, got %d", len(lines))
+	}
+	if lines[0] != "line1" {
+		t.Errorf("Expected 'line1', got '%s'", lines[0])
+	}
+	if lines[1] != "line2" {
+		t.Errorf("Expected 'line2', got '%s'", lines[1])
+	}
+}
+
+func TestLineBuffer_FlushesOnSizeExceeded(t *testing.T) {
+	memWriter := &MemoryWriter{}
+	buffer := NewLineBuffer(memWriter, 20, logger.NewDefaultLogger())
+	
+	buffer.Write("short")
+	lines := memWriter.Lines()
+	if len(lines) != 0 {
+		t.Errorf("Expected 0 lines before buffer full, got %d", len(lines))
+	}
+	
+	buffer.Write("this_is_a_longer_line")
+	lines = memWriter.Lines()
+	if len(lines) != 1 {
+		t.Errorf("Expected 1 line after buffer full, got %d", len(lines))
+	}
+	
+	expected := "short\nthis_is_a_longer_line"
+	if lines[0] != expected {
+		t.Errorf("Expected '%s', got '%s'", expected, lines[0])
+	}
+}
+
+func TestLineBuffer_FlushesOnTimeout(t *testing.T) {
+	memWriter := &MemoryWriter{}
+	buffer := NewLineBuffer(memWriter, 1000, logger.NewDefaultLogger(), 1 * time.Millisecond)
+	
+	buffer.Write("line1")
+	buffer.Write("line2")
+	
+	lines := memWriter.Lines()
+	if len(lines) != 0 {
+		t.Errorf("Expected 0 lines before timeout, got %d", len(lines))
+	}
+	
+	time.Sleep(2 * time.Millisecond)
+	
+	lines = memWriter.Lines()
+	if len(lines) != 1 {
+		t.Errorf("Expected 1 line after timeout, got %d", len(lines))
+	}
+	
+	expected := "line1\nline2"
+	if lines[0] != expected {
+		t.Errorf("Expected '%s', got '%s'", expected, lines[0])
+	}
+}
+
+func TestLineBuffer_FlushesOnClose(t *testing.T) {
+	memWriter := &MemoryWriter{}
+	buffer := NewLineBuffer(memWriter, 1000, logger.NewDefaultLogger())
+	
+	buffer.Write("line1")
+	buffer.Write("line2")
+	
+	lines := memWriter.Lines()
+	if len(lines) != 0 {
+		t.Errorf("Expected 0 lines before close, got %d", len(lines))
+	}
+	
+	buffer.Close()
+	
+	lines = memWriter.Lines()
+	if len(lines) != 1 {
+		t.Errorf("Expected 1 line after close, got %d", len(lines))
+	}
+	
+	expected := "line1\nline2"
+	if lines[0] != expected {
+		t.Errorf("Expected '%s', got '%s'", expected, lines[0])
+	}
+}
+
+func TestLineBuffer_IgnoresWritesAfterClose(t *testing.T) {
+	memWriter := &MemoryWriter{}
+	buffer := NewLineBuffer(memWriter, 1000, logger.NewDefaultLogger())
+	
+	buffer.Write("line1")
+	buffer.Close()
+	buffer.Write("line2")
+	
+	lines := memWriter.Lines()
+	if len(lines) != 1 {
+		t.Errorf("Expected 1 line, got %d", len(lines))
+	}
+	if lines[0] != "line1" {
+		t.Errorf("Expected 'line1', got '%s'", lines[0])
+	}
+}

--- a/spectator/writer/udp_writer.go
+++ b/spectator/writer/udp_writer.go
@@ -6,11 +6,31 @@ import (
 )
 
 type UdpWriter struct {
-	conn   *net.UDPConn
-	logger logger.Logger
+	conn       *net.UDPConn
+	logger     logger.Logger
+	lineBuffer *LineBuffer
+}
+
+type udpDirectWriter struct {
+	*UdpWriter
+}
+
+func (u *udpDirectWriter) Write(line string) {
+	u.UdpWriter.writeDirectly(line)
+}
+
+func (u *udpDirectWriter) Close() error {
+	if u.UdpWriter.conn != nil {
+		return u.UdpWriter.conn.Close()
+	}
+	return nil
 }
 
 func NewUdpWriter(address string, logger logger.Logger) (*UdpWriter, error) {
+	return NewUdpWriterWithBuffer(address, logger, 0)
+}
+
+func NewUdpWriterWithBuffer(address string, logger logger.Logger, bufferSize int) (*UdpWriter, error) {
 	udpAddr, err := net.ResolveUDPAddr("udp", address)
 	if err != nil {
 		return nil, err
@@ -21,10 +41,30 @@ func NewUdpWriter(address string, logger logger.Logger) (*UdpWriter, error) {
 		return nil, err
 	}
 
-	return &UdpWriter{conn, logger}, nil
+	baseWriter := &UdpWriter{
+		conn:   conn,
+		logger: logger,
+	}
+
+	var lineBuffer *LineBuffer
+	if bufferSize > 0 {
+		lineBuffer = NewLineBuffer(&udpDirectWriter{baseWriter}, bufferSize, logger)
+	}
+
+	baseWriter.lineBuffer = lineBuffer
+	return baseWriter, nil
 }
 
 func (u *UdpWriter) Write(line string) {
+	if u.lineBuffer != nil {
+		u.lineBuffer.Write(line)
+		return
+	}
+
+	u.writeDirectly(line)
+}
+
+func (u *UdpWriter) writeDirectly(line string) {
 	u.logger.Debugf("Sending line: %s", line)
 
 	// Methods on conn are thread-safe
@@ -35,5 +75,10 @@ func (u *UdpWriter) Write(line string) {
 }
 
 func (u *UdpWriter) Close() error {
+	if u.lineBuffer != nil {
+		if err := u.lineBuffer.Close(); err != nil {
+			return err
+		}
+	}
 	return u.conn.Close()
 }

--- a/spectator/writer/writer.go
+++ b/spectator/writer/writer.go
@@ -87,6 +87,11 @@ func IsValidOutputLocation(output string) bool {
 
 // NewWriter Create a new writer based on the GetLocation string provided
 func NewWriter(outputLocation string, logger logger.Logger) (Writer, error) {
+	return NewWriterWithBuffer(outputLocation, logger, 0)
+}
+
+// NewWriterWithBuffer Create a new writer with buffer support
+func NewWriterWithBuffer(outputLocation string, logger logger.Logger, bufferSize int) (Writer, error) {
 	switch {
 	case outputLocation == "none":
 		logger.Infof("Initializing NoopWriter")
@@ -105,13 +110,13 @@ func NewWriter(outputLocation string, logger logger.Logger) (Writer, error) {
 		outputLocation = "udp://127.0.0.1:1234"
 		logger.Infof("Initializing UdpWriter with address %s", outputLocation)
 		address := strings.TrimPrefix(outputLocation, "udp://")
-		return NewUdpWriter(address, logger)
+		return NewUdpWriterWithBuffer(address, logger, bufferSize)
 	case outputLocation == "unix":
 		// default unix domain socket for spectatord
 		outputLocation = "unix:///run/spectatord/spectatord.unix"
 		logger.Infof("Initializing UnixgramWriter with path %s", outputLocation)
 		path := strings.TrimPrefix(outputLocation, "unix://")
-		return NewUnixgramWriter(path, logger)
+		return NewUnixgramWriterWithBuffer(path, logger, bufferSize)
 	case strings.HasPrefix(outputLocation, "file://"):
 		logger.Infof("Initializing FileWriter with path %s", outputLocation)
 		filePath := strings.TrimPrefix(outputLocation, "file://")
@@ -119,11 +124,11 @@ func NewWriter(outputLocation string, logger logger.Logger) (Writer, error) {
 	case strings.HasPrefix(outputLocation, "udp://"):
 		logger.Infof("Initializing UdpWriter with address %s", outputLocation)
 		address := strings.TrimPrefix(outputLocation, "udp://")
-		return NewUdpWriter(address, logger)
+		return NewUdpWriterWithBuffer(address, logger, bufferSize)
 	case strings.HasPrefix(outputLocation, "unix://"):
 		logger.Infof("Initializing UnixgramWriter with path %s", outputLocation)
 		path := strings.TrimPrefix(outputLocation, "unix://")
-		return NewUnixgramWriter(path, logger)
+		return NewUnixgramWriterWithBuffer(path, logger, bufferSize)
 	default:
 		return nil, fmt.Errorf("unknown output location: %s", outputLocation)
 	}


### PR DESCRIPTION
- Add bufferSize parameter to Config struct with NewConfigWithBuffer function
- Implement LineBuffer with size-based and time-based (5s) flushing
- Integrate LineBuffer into UdpWriter and UnixgramWriter when buffer size > 0
- Maintain backward compatibility with existing NewUdpWriter and NewUnixgramWriter
- Add comprehensive test coverage for LineBuffer functionality
- Default buffer size is 0 (disabled) to preserve existing behavior