### PR TITLE
add LowLatencyBuffer for improved performance

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.21, 1.22]
+        go-version: [1.23, 1.24]
     steps:
       - uses: actions/checkout@v4
 
@@ -16,21 +16,18 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
 
-      - name: Install dependencies
+      - name: Install Dependencies
         run: |
-          go version
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.57.2
-          golangci-lint --version
+          sudo make install
 
-      - name: Run build
+      - name: Build
         run: |
-          go build ./...
+          make build
 
-      - name: Run tests
+      - name: Test
         run: |
-          go test -race -v ./...
-          golangci-lint run
+          make test
 
-      - name: Run linter
+      - name: Lint
         run: |
-          golangci-lint run
+          make lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.21, 1.22]
+        go-version: [1.23, 1.24]
     steps:
       - uses: actions/checkout@v4
 
@@ -21,21 +21,18 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
 
-      - name: Install dependencies
+      - name: Install Dependencies
         run: |
-          go version
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.57.2
-          golangci-lint --version
+          sudo make install
 
-      - name: Run build
+      - name: Build
         run: |
-          go build ./...
+          make build
 
-      - name: Run tests
+      - name: Test
         run: |
-          go test -race -v ./...
-          golangci-lint run
+          make test
 
-      - name: Run linter
+      - name: Lint
         run: |
-          golangci-lint run
+          make lint

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.21, 1.22]
+        go-version: [1.23, 1.24]
     steps:
       - uses: actions/checkout@v4
 
@@ -20,21 +20,18 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
 
-      - name: Install dependencies
+      - name: Install Dependencies
         run: |
-          go version
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.57.2
-          golangci-lint --version
+          sudo make install
 
-      - name: Run build
+      - name: Build
         run: |
-          go build ./...
+          make build
 
-      - name: Run tests
+      - name: Test
         run: |
-          go test -race -v ./...
-          golangci-lint run
+          make test
 
-      - name: Run linter
+      - name: Lint
         run: |
-          golangci-lint run
+          make lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,22 @@
+version: "2"
 linters:
   disable:
     - errcheck
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,15 @@ tidy:
 	go fmt ./...
 	go mod tidy -v
 
+## build: build the project
+.PHONY: build
+build:
+	go build ./...
+
 ## test: run all tests
 .PHONY: test
 test:
 	go test -race -v ./...
-	golangci-lint run
 
 ## test/cover: run all tests and display coverage
 .PHONY: test/cover
@@ -24,7 +28,19 @@ test/cover:
 	go test -v -race -buildvcs -coverprofile=/tmp/coverage.out ./...
 	go tool cover -html=/tmp/coverage.out
 
-## install: install golangci-lint
+## lint: run golangci-lint
+.PHONY: lint
+lint:
+	golangci-lint run
+
+## bench: run go benchmarks
+.PHONY: bench
+bench:
+	go test -bench=. ./spectator/meter
+
+## install: install golangci-lint and check versions
 .PHONY: install
 install:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.57.2
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.2.1
+	go version
+	golangci-lint --version

--- a/spectator/registry.go
+++ b/spectator/registry.go
@@ -69,7 +69,7 @@ func NewRegistry(config *Config) (Registry, error) {
 		config, _ = NewConfig("", nil, nil)
 	}
 
-	newWriter, err := writer.NewWriterWithBuffer(config.location, config.log, config.bufferSize)
+	newWriter, err := writer.NewWriterWithBuffer(config.location, config.log, config.bufferSize, config.flushInterval)
 	if err != nil {
 		return nil, err
 	}

--- a/spectator/writer/file_writer.go
+++ b/spectator/writer/file_writer.go
@@ -6,13 +6,11 @@ import (
 	"os"
 )
 
-// FileWriter is a writer that writes to a file.
 type FileWriter struct {
 	file   *os.File
 	logger logger.Logger
 }
 
-// NewFileWriter creates a new FileWriter.
 func NewFileWriter(filename string, logger logger.Logger) (*FileWriter, error) {
 	file, err := os.OpenFile(filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
@@ -21,17 +19,22 @@ func NewFileWriter(filename string, logger logger.Logger) (*FileWriter, error) {
 	return &FileWriter{file, logger}, nil
 }
 
-// Write writes a line to the file.
 func (f *FileWriter) Write(line string) {
 	f.logger.Debugf("Sending line: %s", line)
+	f.WriteString(line)
+}
 
+func (f *FileWriter) WriteBytes(line []byte) {
+	f.WriteString(string(line))
+}
+
+func (f *FileWriter) WriteString(line string) {
 	_, err := fmt.Fprintln(f.file, line)
 	if err != nil {
 		f.logger.Errorf("Error writing to file: %s", err)
 	}
 }
 
-// Close closes the file.
 func (f *FileWriter) Close() error {
 	return f.file.Close()
 }

--- a/spectator/writer/file_writer_test.go
+++ b/spectator/writer/file_writer_test.go
@@ -7,10 +7,12 @@ import (
 	"testing"
 )
 
-func TestNewFileWriter(t *testing.T) {
-	defer os.Remove("testfile.txt")
+const testFileName = "test.txt"
 
-	writer, err := NewFileWriter("testfile.txt", logger.NewDefaultLogger())
+func TestNewFileWriter(t *testing.T) {
+	defer os.Remove(testFileName)
+
+	writer, err := NewFileWriter(testFileName, logger.NewDefaultLogger())
 
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
@@ -21,14 +23,42 @@ func TestNewFileWriter(t *testing.T) {
 }
 
 func TestFileWriter_Write(t *testing.T) {
-	defer os.Remove("testfile.txt")
+	defer os.Remove(testFileName)
 
-	writer, _ := NewFileWriter("testfile.txt", logger.NewDefaultLogger())
+	writer, _ := NewFileWriter(testFileName, logger.NewDefaultLogger())
 
 	line := "test line"
 	writer.Write(line)
 
-	content, _ := os.ReadFile("testfile.txt")
+	content, _ := os.ReadFile(testFileName)
+	if strings.TrimRight(string(content), "\n") != line {
+		t.Errorf("Expected '%s', got '%s'", line, string(content))
+	}
+}
+
+func TestFileWriter_WriteBytes(t *testing.T) {
+	defer os.Remove(testFileName)
+
+	writer, _ := NewFileWriter(testFileName, logger.NewDefaultLogger())
+
+	line := "test line"
+	writer.WriteBytes([]byte(line))
+
+	content, _ := os.ReadFile(testFileName)
+	if strings.TrimRight(string(content), "\n") != line {
+		t.Errorf("Expected '%s', got '%s'", line, string(content))
+	}
+}
+
+func TestFileWriter_WriteString(t *testing.T) {
+	defer os.Remove(testFileName)
+
+	writer, _ := NewFileWriter(testFileName, logger.NewDefaultLogger())
+
+	line := "test line"
+	writer.WriteString(line)
+
+	content, _ := os.ReadFile(testFileName)
 	if strings.TrimRight(string(content), "\n") != line {
 		t.Errorf("Expected '%s', got '%s'", line, string(content))
 	}
@@ -36,17 +66,17 @@ func TestFileWriter_Write(t *testing.T) {
 
 // Test using a FileWriter with an existing file
 func TestFileWriter_WriteExistingFile(t *testing.T) {
-	defer os.Remove("testfile.txt")
+	defer os.Remove(testFileName)
 
 	// Create a file with some content
-	os.WriteFile("testfile.txt", []byte("existing content\n"), 0644)
+	os.WriteFile(testFileName, []byte("existing content\n"), 0644)
 
-	writer, _ := NewFileWriter("testfile.txt", logger.NewDefaultLogger())
+	writer, _ := NewFileWriter(testFileName, logger.NewDefaultLogger())
 
 	line := "test line"
 	writer.Write(line)
 
-	content, _ := os.ReadFile("testfile.txt")
+	content, _ := os.ReadFile(testFileName)
 	expected := "existing content\ntest line\n"
 	if string(content) != expected {
 		t.Errorf("Expected '%s', got '%s'", expected, string(content))
@@ -55,9 +85,9 @@ func TestFileWriter_WriteExistingFile(t *testing.T) {
 }
 
 func TestFileWriter_Close(t *testing.T) {
-	defer os.Remove("testfile.txt")
+	defer os.Remove(testFileName)
 
-	writer, _ := NewFileWriter("testfile.txt", logger.NewDefaultLogger())
+	writer, _ := NewFileWriter(testFileName, logger.NewDefaultLogger())
 	err := writer.Close()
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)

--- a/spectator/writer/line_buffer_test.go
+++ b/spectator/writer/line_buffer_test.go
@@ -6,110 +6,90 @@ import (
 	"time"
 )
 
-func TestLineBuffer_DisabledWhenBufferSizeZero(t *testing.T) {
-	memWriter := &MemoryWriter{}
-	buffer := NewLineBuffer(memWriter, 0, logger.NewDefaultLogger())
-	
-	buffer.Write("line1")
-	buffer.Write("line2")
-	
-	lines := memWriter.Lines()
-	if len(lines) != 2 {
-		t.Errorf("Expected 2 lines, got %d", len(lines))
-	}
-	if lines[0] != "line1" {
-		t.Errorf("Expected 'line1', got '%s'", lines[0])
-	}
-	if lines[1] != "line2" {
-		t.Errorf("Expected 'line2', got '%s'", lines[1])
-	}
-}
-
 func TestLineBuffer_FlushesOnSizeExceeded(t *testing.T) {
 	memWriter := &MemoryWriter{}
-	buffer := NewLineBuffer(memWriter, 20, logger.NewDefaultLogger())
-	
+	buffer := NewLineBuffer(memWriter, logger.NewDefaultLogger(), 20, 5*time.Second)
+
 	buffer.Write("short")
 	lines := memWriter.Lines()
 	if len(lines) != 0 {
-		t.Errorf("Expected 0 lines before buffer full, got %d", len(lines))
+		t.Errorf("Expected 0 lines before size exceeded, got %d: %s", len(lines), lines)
 	}
-	
+
 	buffer.Write("this_is_a_longer_line")
 	lines = memWriter.Lines()
-	if len(lines) != 1 {
-		t.Errorf("Expected 1 line after buffer full, got %d", len(lines))
+	if len(lines) != 3 {
+		t.Errorf("Expected 3 lines after buffer size exceeded, got %d: %s", len(lines), lines)
 	}
-	
-	expected := "short\nthis_is_a_longer_line"
-	if lines[0] != expected {
-		t.Errorf("Expected '%s', got '%s'", expected, lines[0])
+
+	expected := [...]string{
+		"c:spectator-go.lineBuffer.overflows:1",
+		"short\nthis_is_a_longer_line",
+		"c:spectator-go.lineBuffer.bytesWritten:27",
+	}
+	for idx, line := range lines {
+		if line != expected[idx] {
+			t.Errorf("Expected '%s', got '%s'", expected[idx], line)
+		}
 	}
 }
 
 func TestLineBuffer_FlushesOnTimeout(t *testing.T) {
 	memWriter := &MemoryWriter{}
-	buffer := NewLineBuffer(memWriter, 1000, logger.NewDefaultLogger(), 1 * time.Millisecond)
-	
+	buffer := NewLineBuffer(memWriter, logger.NewDefaultLogger(), 1000, 1*time.Millisecond)
+
 	buffer.Write("line1")
 	buffer.Write("line2")
-	
+
 	lines := memWriter.Lines()
 	if len(lines) != 0 {
 		t.Errorf("Expected 0 lines before timeout, got %d", len(lines))
 	}
-	
+
 	time.Sleep(2 * time.Millisecond)
-	
+
 	lines = memWriter.Lines()
-	if len(lines) != 1 {
-		t.Errorf("Expected 1 line after timeout, got %d", len(lines))
+	if len(lines) != 2 {
+		t.Errorf("Expected 2 lines after timeout, got %d: %s", len(lines), lines)
 	}
-	
-	expected := "line1\nline2"
-	if lines[0] != expected {
-		t.Errorf("Expected '%s', got '%s'", expected, lines[0])
+
+	expected := [...]string{
+		"line1\nline2",
+		"c:spectator-go.lineBuffer.bytesWritten:11",
+	}
+	for idx, expect := range expected {
+		if expect != lines[idx] {
+			t.Errorf("Expected '%s', got '%s'", expect, lines[idx])
+		}
 	}
 }
 
 func TestLineBuffer_FlushesOnClose(t *testing.T) {
 	memWriter := &MemoryWriter{}
-	buffer := NewLineBuffer(memWriter, 1000, logger.NewDefaultLogger())
-	
+	buffer := NewLineBuffer(memWriter, logger.NewDefaultLogger(), 1000, 5*time.Second)
+
 	buffer.Write("line1")
 	buffer.Write("line2")
-	
+
 	lines := memWriter.Lines()
 	if len(lines) != 0 {
 		t.Errorf("Expected 0 lines before close, got %d", len(lines))
 	}
-	
-	buffer.Close()
-	
-	lines = memWriter.Lines()
-	if len(lines) != 1 {
-		t.Errorf("Expected 1 line after close, got %d", len(lines))
-	}
-	
-	expected := "line1\nline2"
-	if lines[0] != expected {
-		t.Errorf("Expected '%s', got '%s'", expected, lines[0])
-	}
-}
 
-func TestLineBuffer_IgnoresWritesAfterClose(t *testing.T) {
-	memWriter := &MemoryWriter{}
-	buffer := NewLineBuffer(memWriter, 1000, logger.NewDefaultLogger())
-	
-	buffer.Write("line1")
 	buffer.Close()
-	buffer.Write("line2")
-	
-	lines := memWriter.Lines()
-	if len(lines) != 1 {
-		t.Errorf("Expected 1 line, got %d", len(lines))
+
+	lines = memWriter.Lines()
+	if len(lines) != 2 {
+		t.Errorf("Expected 2 lines after close, got %d: %s", len(lines), lines)
 	}
-	if lines[0] != "line1" {
-		t.Errorf("Expected 'line1', got '%s'", lines[0])
+
+	expected := [...]string{
+		"line1\nline2",
+		"c:spectator-go.lineBuffer.bytesWritten:11",
+	}
+	for idx, expect := range expected {
+		if expect != lines[idx] {
+			t.Errorf("Expected '%s', got '%s'", expect, lines[idx])
+		}
 	}
 }

--- a/spectator/writer/lowlatency_buffer.go
+++ b/spectator/writer/lowlatency_buffer.go
@@ -1,0 +1,259 @@
+package writer
+
+import (
+	"fmt"
+	"github.com/Netflix/spectator-go/v2/spectator/logger"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// chunkSize is set to 60KB, to ensure each message fits in the socket buffer (64KB), with some room
+// to accommodate the last spectatord protocol line appended. The maximum length of a well-formed
+// protocol line is 3,927 characters (3.8KB).
+const chunkSize = 60 * 1024
+
+// separator is the character used to indicate the end of a spectatord protocol line, when combining
+// lines into a larger socket payload
+const separator = "\n"
+
+// bufferShard is the atomic unit of buffering, used to store one or more chunks of spectatord
+// protocol lines. Each shard is accessed in round-robin format within either the front buffer
+// or the back buffer, and the number of shards is scaled to the number of CPUs on the system.
+// The purpose of this design is to spread buffer access across a reasonable number of mutexes,
+// in order to reduce overall latency when writing to the buffer. The impact of the shard design
+// is less than the impact of the front and back buffer design, but it is still important for
+// throughput reasons.
+type bufferShard struct {
+	data       [][]byte // Array of chunkSize chunks of spectatord protocol lines, stored as bytes
+	chunkIndex int      // Index of the chunk available for writes
+	overflows  int      // Count the buffer overflows, which correspond to data drops, for reporting metrics
+	mu         sync.Mutex
+}
+
+// getChunkIndexForLine returns the chunkIndex that should be used for storing the line, or -1, if there is
+// an overflow and the line cannot be stored in the bufferShard.
+func (b *bufferShard) getChunkIndexForLine(line []byte) int {
+	// All chunks are full for the shard, drop the data
+	if b.chunkIndex >= len(b.data) {
+		b.overflows++
+		return -1
+	}
+
+	// This should not happen, drop the data. The maximum length of a well-formed protocol line is 3.8KB.
+	if len(line) > chunkSize {
+		b.overflows++
+		return -1
+	}
+
+	totalWriteLength := len(line)
+	if len(b.data[b.chunkIndex]) > 0 {
+		// Chunk has data, so account for the separator character
+		totalWriteLength++
+	}
+
+	if len(b.data[b.chunkIndex])+totalWriteLength > chunkSize {
+		// Line does not fit in the current chunk, go to the next chunk
+		b.chunkIndex++
+	}
+
+	// Out of space in the shard, drop the data
+	if b.chunkIndex == len(b.data) {
+		b.overflows++
+		return -1
+	}
+
+	return b.chunkIndex
+}
+
+type LowLatencyBuffer struct {
+	writer Writer
+	logger logger.Logger
+
+	// Two sets of bufferShard, each scaled to the number of CPUs on the system. There are two sets,
+	// so that one can be drained for writes to the spectatord socket, while the other can be filled
+	// with writes from the application without contending for the same mutexes. They are swapped back
+	// and forth during periodic flushes, according to the flushInterval.
+	frontBuffers    []*bufferShard
+	backBuffers     []*bufferShard
+	bufferSetSize   int
+	useFrontBuffers atomic.Bool
+	flushInterval   time.Duration
+
+	// Distribute writes across the shards in the active buffer, with a round-robin scheme.
+	counter uint64
+
+	stopCh chan struct{}
+	wg     sync.WaitGroup
+}
+
+func NewLowLatencyBuffer(writer Writer, logger logger.Logger, bufferSize int, flushInterval time.Duration) *LowLatencyBuffer {
+	numCPUs := runtime.NumCPU()
+	frontBuffers := make([]*bufferShard, numCPUs)
+	backBuffers := make([]*bufferShard, numCPUs)
+	maxChunks := bufferSize / (2 * numCPUs * chunkSize)
+	if maxChunks < 1 {
+		maxChunks = 1
+		bufferSize = maxChunks * 2 * numCPUs * chunkSize
+	}
+
+	logger.Infof("Initialize LowLatencyBuffer with size %d bytes (%d shards of %d chunks), and flushInterval of %.2f seconds", bufferSize, numCPUs, maxChunks, flushInterval.Seconds())
+
+	for i := 0; i < numCPUs; i++ {
+		frontBuffers[i] = &bufferShard{
+			data:       make([][]byte, maxChunks),
+			chunkIndex: 0,
+			overflows:  0,
+		}
+		backBuffers[i] = &bufferShard{
+			data:       make([][]byte, maxChunks),
+			chunkIndex: 0,
+			overflows:  0,
+		}
+		// Allocate buffer memory up-front
+		for j := 0; j < maxChunks; j++ {
+			frontBuffers[i].data[j] = make([]byte, 0, chunkSize)
+			backBuffers[i].data[j] = make([]byte, 0, chunkSize)
+		}
+	}
+
+	llb := &LowLatencyBuffer{
+		writer:        writer,
+		logger:        logger,
+		frontBuffers:  frontBuffers,
+		backBuffers:   backBuffers,
+		bufferSetSize: bufferSize / 2,
+		flushInterval: flushInterval,
+		stopCh:        make(chan struct{}),
+	}
+
+	llb.useFrontBuffers.Store(true)
+
+	// Start the flush goroutine
+	llb.wg.Add(1)
+	go llb.flushLoop()
+
+	return llb
+}
+
+func (llb *LowLatencyBuffer) Write(line string) {
+	// Pick a shard index across all shards in the active buffer, with a round-robin distribution
+	shardIndex := int(atomic.AddUint64(&llb.counter, 1)) % len(llb.frontBuffers)
+
+	// Acquire read lock, to check which buffers are active
+	var buffer *bufferShard
+	if llb.useFrontBuffers.Load() {
+		buffer = llb.frontBuffers[shardIndex]
+	} else {
+		buffer = llb.backBuffers[shardIndex]
+	}
+
+	// Add the line to the appropriate chunk in the buffer shard, or drop, if it overflows
+	buffer.mu.Lock()
+	defer buffer.mu.Unlock()
+	lineBytes := []byte(line)
+
+	// Check if current chunk can fit the new data
+	idx := buffer.getChunkIndexForLine(lineBytes)
+	if idx == -1 {
+		// overflows (drops) are counted in getChunkIndexForLine, for metric reporting
+		return
+	}
+
+	// We can write to the selected chunk
+	if len(buffer.data[buffer.chunkIndex]) > 0 {
+		// buffer has data, so add the separator, to indicate the end of the previous line
+		buffer.data[buffer.chunkIndex] = append(buffer.data[buffer.chunkIndex], []byte(separator)...)
+	}
+	buffer.data[buffer.chunkIndex] = append(buffer.data[buffer.chunkIndex], lineBytes...)
+}
+
+// flushLoop runs in a separate goroutine and handles buffer swapping and flushing
+func (llb *LowLatencyBuffer) flushLoop() {
+	defer llb.wg.Done()
+
+	ticker := time.NewTicker(llb.flushInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			llb.swapAndFlush()
+		case <-llb.stopCh:
+			// Final flush before shutdown
+			llb.swapAndFlush()
+			return
+		}
+	}
+}
+
+// swapAndFlush swaps the front and back buffers and flushes the deactivated buffers
+func (llb *LowLatencyBuffer) swapAndFlush() {
+	// Swap the buffer sets, so one can be drained, while the other accepts application writes
+	old := llb.useFrontBuffers.Load()
+	llb.useFrontBuffers.CompareAndSwap(old, !old)
+
+	var bufferSet string
+	var buffersToFlush []*bufferShard
+	if llb.useFrontBuffers.Load() {
+		// Front buffers are now in use for application writes, so flush the back buffers
+		bufferSet = "back"
+		buffersToFlush = llb.backBuffers
+	} else {
+		// Back buffers are now in use application writes, so flush the front buffers
+		bufferSet = "front"
+		buffersToFlush = llb.frontBuffers
+	}
+
+	// Flush each buffer shard, from the deactivated set
+	var bytesWritten int
+	for _, buffer := range buffersToFlush {
+		bytesWritten += llb.flushBufferShard(buffer, bufferSet)
+	}
+
+	pctUsage := float64(bytesWritten) / float64(llb.bufferSetSize)
+	if bytesWritten > 0 {
+		llb.writer.WriteString(fmt.Sprintf("c:spectator-go.lowLatencyBuffer.bytesWritten,bufferSet=%s:%d", bufferSet, bytesWritten))
+	}
+	if pctUsage > 0 {
+		llb.writer.WriteString(fmt.Sprintf("g,1:spectator-go.lowLatencyBuffer.pctUsage,bufferSet=%s:%f", bufferSet, pctUsage))
+	}
+}
+
+// flushBufferShard flushes a single bufferShard to the socket, iterating through all chunks
+func (llb *LowLatencyBuffer) flushBufferShard(buffer *bufferShard, bufferSet string) int {
+	buffer.mu.Lock()
+	defer buffer.mu.Unlock()
+
+	// If there is no data to flush from the shard, then skip socket writes
+	if buffer.chunkIndex == 0 && len(buffer.data[0]) == 0 {
+		return 0
+	}
+
+	// Write each chunk to the socket, and reset the chunk
+	var bytesWritten int
+	for i := 0; i <= buffer.chunkIndex && i < len(buffer.data); i++ {
+		if len(buffer.data[i]) > 0 {
+			bytesWritten += len(buffer.data[i])
+			llb.writer.WriteBytes(buffer.data[i])
+			buffer.data[i] = buffer.data[i][:0]
+		}
+	}
+
+	// record status metrics and reset shard statistics
+	if buffer.overflows > 0 {
+		llb.writer.WriteString(fmt.Sprintf("c:spectator-go.lowLatencyBuffer.overflows,bufferSet=%s:%d", bufferSet, buffer.overflows))
+		buffer.overflows = 0
+	}
+	buffer.chunkIndex = 0
+	return bytesWritten
+}
+
+func (llb *LowLatencyBuffer) Close() {
+	// Signal the flush goroutine to stop
+	close(llb.stopCh)
+
+	// Wait for the goroutine to finish
+	llb.wg.Wait()
+}

--- a/spectator/writer/lowlatency_buffer_test.go
+++ b/spectator/writer/lowlatency_buffer_test.go
@@ -1,0 +1,192 @@
+package writer
+
+import (
+	"fmt"
+	"github.com/Netflix/spectator-go/v2/spectator/logger"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func splitAndFilterMetricLines(memWriter *MemoryWriter) []string {
+	var lines []string
+	for _, mwLine := range memWriter.Lines() {
+		for _, protocolLine := range strings.Split(mwLine, separator) {
+			if strings.Contains(protocolLine, "spectator-go.lowLatencyBuffer") {
+				// The number of buffer stats metric lines depends on flush activity - discard
+				continue
+			}
+			lines = append(lines, protocolLine)
+		}
+	}
+	return lines
+}
+
+func TestLowLatencyBuffer_ShardMessageDistribution(t *testing.T) {
+	memWriter := &MemoryWriter{}
+	shards := runtime.NumCPU()
+	bufferSize := 2 * 2 * chunkSize * shards // two buffer sets, two 60 KB chunks/shard
+	buffer := NewLowLatencyBuffer(memWriter, logger.NewDefaultLogger(), bufferSize, 5*time.Millisecond)
+	defer buffer.Close()
+
+	// Verify that the buffer sets have the expected shard count
+	if len(buffer.frontBuffers) != shards {
+		t.Errorf("Expected %d shards in the front buffer set, got %d", shards, len(buffer.frontBuffers))
+	}
+	if len(buffer.backBuffers) != shards {
+		t.Errorf("Expected %d shards in the back buffer set, got %d", shards, len(buffer.backBuffers))
+	}
+
+	// Write messages and verify they're distributed across buffer shards
+	numMessages := shards * 10
+	for i := 0; i < numMessages; i++ {
+		buffer.Write(fmt.Sprintf("message=%v,", i))
+	}
+
+	// Check that multiple buffer shards have data
+	shardsWithData := 0
+	for _, shard := range buffer.frontBuffers {
+		shard.mu.Lock()
+		if len(shard.data) > 0 {
+			shardsWithData++
+		}
+		shard.mu.Unlock()
+	}
+
+	if shardsWithData == 0 {
+		t.Error("No buffer shards have data, data distribution may not be working")
+	}
+
+	// Wait for flush and verify all messages are received, filtering out statistics metrics
+	time.Sleep(15 * time.Millisecond)
+
+	lines := splitAndFilterMetricLines(memWriter)
+	if len(lines) != numMessages {
+		t.Errorf("Expected %d protocol lines in MemoryWriter, got %d", numMessages, len(lines))
+	}
+}
+
+func TestLowLatencyBuffer_FrontBuffersFlushFirst(t *testing.T) {
+	// Create a buffer instance with a long flush interval timer, to allow for manual flush trigger
+	memWriter := &MemoryWriter{}
+	shards := runtime.NumCPU()
+	bufferSize := 2 * 2 * chunkSize * shards // two buffer sets, two 60 KB chunks/shard
+	buffer := NewLowLatencyBuffer(memWriter, logger.NewDefaultLogger(), bufferSize, 3*time.Minute)
+	defer buffer.Close()
+
+	if buffer.useFrontBuffers.Load() != true {
+		t.Errorf("Expected useFrontBuffers to be true")
+	}
+
+	// Ensure that buffer swapping and flushing logic is correct
+	buffer.Write("message1")
+	buffer.swapAndFlush()
+
+	if buffer.useFrontBuffers.Load() != false {
+		t.Errorf("Expected useFrontBuffers to be false")
+	}
+
+	lines := splitAndFilterMetricLines(memWriter)
+	if len(lines) != 1 {
+		t.Errorf("Expected %d lines in the front buffer set, got %d", 1, len(lines))
+	}
+	if lines[0] != "message1" {
+		t.Errorf("Expected first message to be message1, got %s", lines[0])
+	}
+}
+
+func TestLowLatencyBuffer_ChunkBoundaries_HalfSize(t *testing.T) {
+	// Create a buffer instance with a long flush interval timer, to allow for manual flush trigger
+	memWriter := &MemoryWriter{}
+	shards := runtime.NumCPU()
+	bufferSize := 2 * 2 * chunkSize * shards // two buffer sets, two 60 KB chunks/shard
+	buffer := NewLowLatencyBuffer(memWriter, logger.NewDefaultLogger(), bufferSize, 3*time.Minute)
+	defer buffer.Close()
+
+	var totalMessages int
+
+	// Fill all chunks with half the max size message
+	for i := 0; i < 2; i++ {
+		for j := 0; j < shards; j++ {
+			msg := strings.Repeat("x", chunkSize/2)
+			buffer.Write(msg)
+			totalMessages++
+		}
+	}
+
+	buffer.swapAndFlush()
+
+	// Verify the total number of lines received
+	lines := splitAndFilterMetricLines(memWriter)
+	if len(lines) != totalMessages {
+		t.Errorf("Expected %d lines, got %d", totalMessages, len(lines))
+	}
+
+	// Verify the messages match the chunk size
+	for _, line := range lines {
+		if len(line) != chunkSize/2 {
+			t.Errorf("Expected %d message size, got %d", chunkSize/2, len(line))
+		}
+	}
+}
+
+func TestLowLatencyBuffer_ChunkBoundaries_MaxSize(t *testing.T) {
+	// Create a buffer instance with a long flush interval timer, to allow for manual flush trigger
+	memWriter := &MemoryWriter{}
+	shards := runtime.NumCPU()
+	bufferSize := 2 * 2 * chunkSize * shards // two buffer sets, two 60 KB chunks/shard
+	buffer := NewLowLatencyBuffer(memWriter, logger.NewDefaultLogger(), bufferSize, 3*time.Minute)
+	defer buffer.Close()
+
+	var totalMessages int
+
+	// Fill all chunks with the max size message
+	for i := 0; i < 2; i++ {
+		for j := 0; j < shards; j++ {
+			msg := strings.Repeat("x", chunkSize)
+			buffer.Write(msg)
+			totalMessages++
+		}
+	}
+
+	buffer.swapAndFlush()
+
+	// Verify the total number of lines received
+	lines := splitAndFilterMetricLines(memWriter)
+	if len(lines) != totalMessages {
+		t.Errorf("Expected %d lines, got %d", totalMessages, len(lines))
+	}
+
+	// Verify the messages match the chunk size
+	for _, line := range lines {
+		if len(line) != chunkSize {
+			t.Errorf("Expected %d message size, got %d", chunkSize, len(line))
+		}
+	}
+}
+
+func TestLowLatencyBuffer_ChunkBoundaries_OverMaxSizeIsDropped(t *testing.T) {
+	// Create a buffer instance with a long flush interval timer, to allow for manual flush trigger
+	memWriter := &MemoryWriter{}
+	shards := runtime.NumCPU()
+	bufferSize := 2 * 2 * chunkSize * shards // two buffer sets, two 60 KB chunks/shard
+	buffer := NewLowLatencyBuffer(memWriter, logger.NewDefaultLogger(), bufferSize, 3*time.Minute)
+	defer buffer.Close()
+
+	// Fill all chunks with an over max size message
+	for i := 0; i < 2; i++ {
+		for j := 0; j < shards; j++ {
+			msg := strings.Repeat("x", chunkSize + 1)
+			buffer.Write(msg)
+		}
+	}
+
+	buffer.swapAndFlush()
+
+	// Verify the total number of lines received
+	lines := splitAndFilterMetricLines(memWriter)
+	if len(lines) != 0 {
+		t.Errorf("Expected %d lines, got %d", 0, len(lines))
+	}
+}

--- a/spectator/writer/memory_writer.go
+++ b/spectator/writer/memory_writer.go
@@ -1,0 +1,42 @@
+package writer
+
+import (
+	"slices"
+	"sync"
+)
+
+// MemoryWriter stores lines in memory in an array, so updates can be inspected for test validation.
+type MemoryWriter struct {
+	lines []string
+	mu    sync.RWMutex
+}
+
+func (m *MemoryWriter) Write(line string) {
+	m.WriteString(line)
+}
+
+func (m *MemoryWriter) WriteBytes(line []byte) {
+	m.WriteString(string(line))
+}
+
+func (m *MemoryWriter) WriteString(line string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.lines = append(m.lines, line)
+}
+
+func (m *MemoryWriter) Lines() []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return slices.Clone(m.lines)
+}
+
+func (m *MemoryWriter) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.lines = []string{}
+}
+
+func (m *MemoryWriter) Close() error {
+	return nil
+}

--- a/spectator/writer/noop_writer.go
+++ b/spectator/writer/noop_writer.go
@@ -1,0 +1,14 @@
+package writer
+
+// NoopWriter is a writer that does nothing.
+type NoopWriter struct{}
+
+func (n *NoopWriter) Write(_ string) {}
+
+func (n *NoopWriter) WriteBytes(_ []byte) {}
+
+func (n *NoopWriter) WriteString(_ string) {}
+
+func (n *NoopWriter) Close() error {
+	return nil
+}

--- a/spectator/writer/stderr_writer.go
+++ b/spectator/writer/stderr_writer.go
@@ -1,0 +1,25 @@
+package writer
+
+import (
+	"fmt"
+	"os"
+)
+
+// StderrWriter is a writer that writes to stderr.
+type StderrWriter struct{}
+
+func (s *StderrWriter) Write(line string) {
+	s.WriteString(line)
+}
+
+func (s *StderrWriter) WriteBytes(line []byte) {
+	s.WriteString(string(line))
+}
+
+func (s *StderrWriter) WriteString(line string) {
+	_, _ = fmt.Fprintln(os.Stderr, line)
+}
+
+func (s *StderrWriter) Close() error {
+	return nil
+}

--- a/spectator/writer/stdout_writer.go
+++ b/spectator/writer/stdout_writer.go
@@ -1,0 +1,25 @@
+package writer
+
+import (
+	"fmt"
+	"os"
+)
+
+// StdoutWriter is a writer that writes to stdout.
+type StdoutWriter struct{}
+
+func (s *StdoutWriter) Write(line string) {
+	s.WriteString(line)
+}
+
+func (s *StdoutWriter) WriteBytes(line []byte) {
+	s.WriteString(string(line))
+}
+
+func (s *StdoutWriter) WriteString(line string) {
+	_, _ = fmt.Fprintln(os.Stdout, line)
+}
+
+func (s *StdoutWriter) Close() error {
+	return nil
+}

--- a/spectator/writer/unixgram_writer.go
+++ b/spectator/writer/unixgram_writer.go
@@ -4,35 +4,26 @@ import (
 	"github.com/Netflix/spectator-go/v2/spectator/logger"
 	"net"
 	"strings"
+	"time"
 )
 
 type UnixgramWriter struct {
-	addr       *net.UnixAddr
-	conn       *net.UnixConn
-	logger     logger.Logger
-	lineBuffer *LineBuffer
+	addr             *net.UnixAddr
+	conn             *net.UnixConn
+	logger           logger.Logger
+	lineBuffer       *LineBuffer
+	lowLatencyBuffer *LowLatencyBuffer
 }
 
-type unixgramDirectWriter struct {
+type unixgramBufferWriter struct {
 	*UnixgramWriter
 }
 
-func (u *unixgramDirectWriter) Write(line string) {
-	u.UnixgramWriter.writeDirectly(line)
-}
-
-func (u *unixgramDirectWriter) Close() error {
-	if u.UnixgramWriter.conn != nil {
-		return u.UnixgramWriter.conn.Close()
-	}
-	return nil
-}
-
 func NewUnixgramWriter(path string, logger logger.Logger) (*UnixgramWriter, error) {
-	return NewUnixgramWriterWithBuffer(path, logger, 0)
+	return NewUnixgramWriterWithBuffer(path, logger, 0, 5 * time.Second)
 }
 
-func NewUnixgramWriterWithBuffer(path string, logger logger.Logger, bufferSize int) (*UnixgramWriter, error) {
+func NewUnixgramWriterWithBuffer(path string, logger logger.Logger, bufferSize int, flushInterval time.Duration) (*UnixgramWriter, error) {
 	addr := &net.UnixAddr{Name: path, Net: "unixgram"}
 	conn, err := net.DialUnix("unixgram", nil, addr)
 	if err != nil {
@@ -47,12 +38,52 @@ func NewUnixgramWriterWithBuffer(path string, logger logger.Logger, bufferSize i
 	}
 
 	var lineBuffer *LineBuffer
-	if bufferSize > 0 {
-		lineBuffer = NewLineBuffer(&unixgramDirectWriter{baseWriter}, bufferSize, logger)
+	var lowLatencyBuffer *LowLatencyBuffer
+	if bufferSize > 0 && bufferSize <= 65536 {
+		lineBuffer = NewLineBuffer(&unixgramBufferWriter{baseWriter}, logger, bufferSize, flushInterval)
+	} else if bufferSize > 0 {
+		lowLatencyBuffer = NewLowLatencyBuffer(&unixgramBufferWriter{baseWriter}, logger, bufferSize, flushInterval)
+	}
+	baseWriter.lineBuffer = lineBuffer
+	baseWriter.lowLatencyBuffer = lowLatencyBuffer
+
+	return baseWriter, nil
+}
+
+func (u *UnixgramWriter) Write(line string) {
+	u.logger.Debugf("Sending line: %s", line)
+
+	if u.lineBuffer != nil {
+		u.lineBuffer.Write(line)
+		return
 	}
 
-	baseWriter.lineBuffer = lineBuffer
-	return baseWriter, nil
+	if u.lowLatencyBuffer != nil {
+		u.lowLatencyBuffer.Write(line)
+		return
+	}
+
+	u.WriteString(line)
+}
+
+func (u *UnixgramWriter) WriteBytes(line []byte) {
+	if u.conn != nil {
+		if _, err := u.conn.Write(line); err != nil {
+			u.maybeCloseSocket(err)
+		}
+	} else {
+		u.redialSocket()
+	}
+}
+
+func (u *UnixgramWriter) WriteString(line string) {
+	if u.conn != nil {
+		if _, err := u.conn.Write([]byte(line)); err != nil {
+			u.maybeCloseSocket(err)
+		}
+	} else {
+		u.redialSocket()
+	}
 }
 
 // If anything disturbs access to the unix socket, such as a spectatord process restart (or another
@@ -67,51 +98,46 @@ func NewUnixgramWriterWithBuffer(path string, logger logger.Logger, bufferSize i
 // The addition of reconnect logic to the UnixgramWriter mitigates ongoing issues with unix socket write
 // errors. Some packet delivery failure will occur until it can reconnect. With the reconnect logic in
 // place, the initialization is now more resilient if the unix socket is not available at program start.
-func (u *UnixgramWriter) Write(line string) {
-	if u.lineBuffer != nil {
-		u.lineBuffer.Write(line)
-		return
-	}
+func (u *UnixgramWriter) maybeCloseSocket(err error) {
+	u.logger.Errorf("failed to write to unix socket: %v\n", err)
 
-	u.writeDirectly(line)
-}
-
-func (u *UnixgramWriter) writeDirectly(line string) {
-	u.logger.Debugf("Sending line: %s", line)
-
-	if u.conn != nil {
-		if _, err := u.conn.Write([]byte(line)); err != nil {
-			u.logger.Errorf("failed to write to unix socket: %v\n", err)
-
-			if strings.Contains(err.Error(), "transport endpoint is not connected") {
-				u.logger.Infof("close unix socket")
-				err := u.conn.Close()
-				if err != nil {
-					u.logger.Errorf("failed to close unix socket: %v\n", err)
-				}
-				u.conn = nil
-			}
-		}
-	} else {
-		u.logger.Infof("re-dial unix socket")
-
-		conn, err := net.DialUnix("unixgram", nil, u.addr)
+	if strings.Contains(err.Error(), "transport endpoint is not connected") {
+		u.logger.Infof("close unix socket")
+		err := u.conn.Close()
 		if err != nil {
-			u.logger.Errorf("failed to dial unix socket: %v", err)
-		} else {
-			u.conn = conn
+			u.logger.Errorf("failed to close unix socket: %v\n", err)
 		}
+		u.conn = nil
 	}
 }
+
+func (u *UnixgramWriter) redialSocket() {
+	u.logger.Infof("re-dial unix socket")
+
+	conn, err := net.DialUnix("unixgram", nil, u.addr)
+	if err != nil {
+		u.logger.Errorf("failed to dial unix socket: %v", err)
+	} else {
+		u.conn = conn
+	}
+}
+
 
 func (u *UnixgramWriter) Close() error {
+	// Stop flush timer, and flush remaining lines
 	if u.lineBuffer != nil {
-		if err := u.lineBuffer.Close(); err != nil {
-			return err
-		}
+		u.lineBuffer.Close()
 	}
+
+	// Stop flush goroutines
+	if u.lowLatencyBuffer != nil {
+		u.lowLatencyBuffer.Close()
+	}
+
+	// Close the connection
 	if u.conn != nil {
 		return u.conn.Close()
 	}
+
 	return nil
 }


### PR DESCRIPTION
The introduction of the LineBuffer allowed spectator-go to approach the ~1M lines/sec maximum ingestion rate of spectatord, without dropping protocol lines. The maximum size of this buffer must remain less than the 64KB socket buffer size. The line rate of this buffer comes at the cost of latency per increment, which can range from 4 to 15 us, depending upon thread count and metrics updates. This delay is too slow for highly concurrent applications.

This change adds a LowLatencyBuffer which allows for much larger buffer sizes, into the hundreds of MB, while maintaining low latency. The line rate for this buffer can approach the ~1M lines/sec maximum ingestion rate of spectatord, but if the application runs too fast, the flush interval is too big, and the buffers are not large enough, then it will drop metrics. However, it continue delivering low latency under all of these conditions, which is achieved with arrays of mutexes that scale based upon CPU count and buffer size.

Thus, this library now has three modes of operation available, for applications that operate at different scales:

* **Small.** No buffer (size 0 bytes). Write immediately to the socket upon every metric update, up to ~150K lines/sec, with delays from 1 to 450 us, depending on thread count. No metrics are dropped.
* **Medium.** LineBuffer (size <= 65536 bytes), which writes to the socket upon overflow, or upon a flush interval, up to ~1M lines/sec, with delays from 1 to 32 us, depending on thread count. No metrics are dropped. Status metrics are published to monitor usage.
* **Large.** LowLatencyBuffer (size > 65536 bytes), which writes to the socket on a flush interval, up to ~1M lines/sec, with delays from 1 to 7 us, depending on thread count. The true minimum size is 2 * CPU * 60KB, or 122,880 bytes for 1 CPU. Metrics may be dropped. Status metrics are published to monitor usage.

The buffers are available for the UdpWriter and the UnixWriter.

Summary of additional changes:

- Extract additional writers from writers.go to keep them separate
- Refactor the Writer interface, to support buffers
- Update GitHub Actions and Makefile for Go 1.23 and Go 1.24
- Update golangci-lint and config to version 2.2.1