### PR TITLE
Improve on toSpectatorId

### DIFF
--- a/spectator/meter/id.go
+++ b/spectator/meter/id.go
@@ -143,27 +143,28 @@ func (id *Id) WithTags(tags map[string]string) *Id {
 }
 
 func toSpectatorId(name string, tags map[string]string) string {
-	result := replaceInvalidCharacters(name)
+	var sb strings.Builder
+	writeSanitized(&sb, name)
 
+	// Append sanitized keys and values.
 	for k, v := range tags {
-		k = replaceInvalidCharacters(k)
-		v = replaceInvalidCharacters(v)
-		result += fmt.Sprintf(",%s=%s", k, v)
+		sb.WriteString(",")
+		writeSanitized(&sb, k)
+		sb.WriteString("=")
+		writeSanitized(&sb, v)
 	}
 
-	return result
+	return sb.String()
 }
 
-func replaceInvalidCharacters(input string) string {
-	var result strings.Builder
+func writeSanitized(sb *strings.Builder, input string) {
 	for _, r := range input {
 		if !isValidCharacter(r) {
-			result.WriteRune('_')
+			sb.WriteRune('_')
 		} else {
-			result.WriteRune(r)
+			sb.WriteRune(r)
 		}
 	}
-	return result.String()
 }
 
 func isValidCharacter(r rune) bool {


### PR DESCRIPTION
The existing implementation when creating a `NewId` generates a significant amount of allocations due to concatenating strings in `toSpectatorId`. 

This commit moves it to using a strings.Builder.

```
goos: darwin
goarch: arm64
pkg: github.com/Netflix/spectator-go/v2/spectator/meter
cpu: Apple M3 Pro
BenchmarkToSpectatorId-12         9054499   1323 ns/op 1290 B/op 40 allocs/op
BenchmarkToSpectatorIdBuilder-12 18567895  656.0 ns/op  504 B/op  6 allocs/op
```