### PR TITLE
perf: reduce meter allocations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
 CLAUDE.md
+*.test

--- a/spectator/meter/age_gauge.go
+++ b/spectator/meter/age_gauge.go
@@ -1,7 +1,6 @@
 package meter
 
 import (
-	"fmt"
 	"github.com/Netflix/spectator-go/v2/spectator/writer"
 )
 
@@ -31,13 +30,11 @@ func (g *AgeGauge) MeterId() *Id {
 // Set records the current time in seconds since the epoch.
 func (g *AgeGauge) Set(seconds int64) {
 	if seconds >= 0 {
-		var line = fmt.Sprintf("%s:%s:%d", g.meterTypeSymbol, g.id.spectatordId, seconds)
-		g.writer.Write(line)
+		writeLineInt(g.writer, g.meterTypeSymbol, g.id.spectatordId, seconds)
 	}
 }
 
 // Now records the current time in epoch seconds, using a spectatord feature.
 func (g *AgeGauge) Now() {
-	var line = fmt.Sprintf("%s:%s:0", g.meterTypeSymbol, g.id.spectatordId)
-	g.writer.Write(line)
+	writeLineInt(g.writer, g.meterTypeSymbol, g.id.spectatordId, 0)
 }

--- a/spectator/meter/bench_hotpath_test.go
+++ b/spectator/meter/bench_hotpath_test.go
@@ -1,15 +1,15 @@
 package meter
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/Netflix/spectator-go/v2/spectator/writer"
 )
 
-// BenchmarkCounterAddHotPath measures the full hot path:
-// NewId (tag copy + toSpectatorId) → NewCounter → Add (fmt.Sprintf + writer.Write).
-// This is the dominant allocation pattern seen in production heap profiles.
-func BenchmarkCounterAddHotPath(b *testing.B) {
+// BenchmarkCounterAddCombined measures a combined meter creation and write path:
+// NewId (tag copy + toSpectatorIdFromFlat) → NewCounter → Add (writeLineInt + writer.Write).
+func BenchmarkCounterAddCombined(b *testing.B) {
 	w := &writer.NoopWriter{}
 	tags := map[string]string{
 		"nf.app":     "meshcontrol-xds",
@@ -22,6 +22,30 @@ func BenchmarkCounterAddHotPath(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
+		c := NewCounter(NewId("spectator.meter.count", tags), w)
+		c.Add(1)
+	}
+}
+
+// BenchmarkCounterAddCombinedPostGC measures the combined path with periodic GC to validate
+// pool repopulation cost. With a single shared byteBufPool, only one buffer
+// allocation is needed per P after GC (vs two with separate pools).
+func BenchmarkCounterAddCombinedPostGC(b *testing.B) {
+	w := &writer.NoopWriter{}
+	tags := map[string]string{
+		"nf.app":     "meshcontrol-xds",
+		"nf.cluster": "meshcontrol-xds-main",
+		"nf.asg":     "meshcontrol-xds-main-v042",
+		"nf.region":  "us-east-1",
+		"id":         "envoy.cluster.upstream_cx_active",
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if i%1024 == 0 {
+			runtime.GC()
+		}
 		c := NewCounter(NewId("spectator.meter.count", tags), w)
 		c.Add(1)
 	}

--- a/spectator/meter/bench_hotpath_test.go
+++ b/spectator/meter/bench_hotpath_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // BenchmarkCounterAddCombined measures a combined meter creation and write path:
-// NewId (tag copy + toSpectatorIdFromFlat) → NewCounter → Add (writeLineInt + writer.Write).
+// NewId (tag copy + toSpectatorIdFromPairs) → NewCounter → Add (writeLineInt + writer.Write).
 func BenchmarkCounterAddCombined(b *testing.B) {
 	w := &writer.NoopWriter{}
 	tags := map[string]string{

--- a/spectator/meter/bench_hotpath_test.go
+++ b/spectator/meter/bench_hotpath_test.go
@@ -1,0 +1,28 @@
+package meter
+
+import (
+	"testing"
+
+	"github.com/Netflix/spectator-go/v2/spectator/writer"
+)
+
+// BenchmarkCounterAddHotPath measures the full hot path:
+// NewId (tag copy + toSpectatorId) → NewCounter → Add (fmt.Sprintf + writer.Write).
+// This is the dominant allocation pattern seen in production heap profiles.
+func BenchmarkCounterAddHotPath(b *testing.B) {
+	w := &writer.NoopWriter{}
+	tags := map[string]string{
+		"nf.app":     "meshcontrol-xds",
+		"nf.cluster": "meshcontrol-xds-main",
+		"nf.asg":     "meshcontrol-xds-main-v042",
+		"nf.region":  "us-east-1",
+		"id":         "envoy.cluster.upstream_cx_active",
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c := NewCounter(NewId("spectator.meter.count", tags), w)
+		c.Add(1)
+	}
+}

--- a/spectator/meter/counter.go
+++ b/spectator/meter/counter.go
@@ -1,7 +1,6 @@
 package meter
 
 import (
-	"fmt"
 	"github.com/Netflix/spectator-go/v2/spectator/writer"
 )
 
@@ -30,22 +29,19 @@ func (c *Counter) MeterId() *Id {
 
 // Increment increments the counter.
 func (c *Counter) Increment() {
-	var line = fmt.Sprintf("%s:%s:%d", c.meterTypeSymbol, c.id.spectatordId, 1)
-	c.writer.Write(line)
+	writeLineInt(c.writer, c.meterTypeSymbol, c.id.spectatordId, 1)
 }
 
 // Add adds an int64 delta to the current measurement.
 func (c *Counter) Add(delta int64) {
 	if delta > 0 {
-		var line = fmt.Sprintf("%s:%s:%d", c.meterTypeSymbol, c.id.spectatordId, delta)
-		c.writer.Write(line)
+		writeLineInt(c.writer, c.meterTypeSymbol, c.id.spectatordId, delta)
 	}
 }
 
 // AddFloat adds a float64 delta to the current measurement.
 func (c *Counter) AddFloat(delta float64) {
 	if delta > 0.0 {
-		var line = fmt.Sprintf("%s:%s:%f", c.meterTypeSymbol, c.id.spectatordId, delta)
-		c.writer.Write(line)
+		writeLineFloat(c.writer, c.meterTypeSymbol, c.id.spectatordId, delta)
 	}
 }

--- a/spectator/meter/dist_summary.go
+++ b/spectator/meter/dist_summary.go
@@ -1,7 +1,6 @@
 package meter
 
 import (
-	"fmt"
 	"github.com/Netflix/spectator-go/v2/spectator/writer"
 )
 
@@ -32,7 +31,6 @@ func (d *DistributionSummary) MeterId() *Id {
 // Record records a value to track within the distribution.
 func (d *DistributionSummary) Record(amount int64) {
 	if amount >= 0 {
-		var line = fmt.Sprintf("%s:%s:%d", d.meterTypeSymbol, d.id.spectatordId, amount)
-		d.writer.Write(line)
+		writeLineInt(d.writer, d.meterTypeSymbol, d.id.spectatordId, amount)
 	}
 }

--- a/spectator/meter/gauge.go
+++ b/spectator/meter/gauge.go
@@ -2,8 +2,9 @@ package meter
 
 import (
 	"fmt"
-	"github.com/Netflix/spectator-go/v2/spectator/writer"
 	"time"
+
+	"github.com/Netflix/spectator-go/v2/spectator/writer"
 )
 
 // Gauge represents a value that is sampled at a specific point in time. One
@@ -37,6 +38,5 @@ func (g *Gauge) MeterId() *Id {
 
 // Set records the current value.
 func (g *Gauge) Set(value float64) {
-	var line = fmt.Sprintf("%s:%s:%f", g.meterTypeSymbol, g.id.spectatordId, value)
-	g.writer.Write(line)
+	writeLineFloat(g.writer, g.meterTypeSymbol, g.id.spectatordId, value)
 }

--- a/spectator/meter/id.go
+++ b/spectator/meter/id.go
@@ -10,7 +10,10 @@ import (
 // Id represents a meter's identifying information and dimensions (tags).
 type Id struct {
 	name string
-	tags map[string]string
+	// flatTags stores tags as a flat [k1, v1, k2, v2, ...] slice.
+	// This avoids the two allocations (hmap header + initial bucket) that a
+	// map[string]string would require when the map escapes to the heap.
+	flatTags []string
 	// keyOnce protects access to key, allowing it to be computed on demand
 	// without racing other readers.
 	keyOnce sync.Once
@@ -19,9 +22,19 @@ type Id struct {
 	spectatordId string
 }
 
-var builderPool = &sync.Pool{
+var builderPool = sync.Pool{
 	New: func() interface{} {
 		return &strings.Builder{}
+	},
+}
+
+// spectatorIdBufPool holds reusable byte-slice buffers for toSpectatorIdFromFlat.
+// Using *[]byte (not strings.Builder) so we can preserve capacity across calls
+// by resetting to len=0 without clearing the backing array.
+var spectatorIdBufPool = sync.Pool{
+	New: func() interface{} {
+		b := make([]byte, 0, 256)
+		return &b
 	},
 }
 
@@ -46,14 +59,29 @@ func (id *Id) MapKey() string {
 			if err != nil {
 				return errKey
 			}
-			keys := make([]string, 0, len(id.tags))
-			for k := range id.tags {
-				keys = append(keys, k)
+
+			n := len(id.flatTags) / 2
+			if n == 0 {
+				return buf.String()
+			}
+
+			// Extract keys for sorting
+			keys := make([]string, 0, n)
+			for i := 0; i+1 < len(id.flatTags); i += 2 {
+				keys = append(keys, id.flatTags[i])
 			}
 			sort.Strings(keys)
 
+			// Build a temporary map for O(1) value lookup during key emission.
+			// MapKey is called at most once per Id (result is cached), so this
+			// transient allocation is acceptable.
+			lookup := make(map[string]string, n)
+			for i := 0; i+1 < len(id.flatTags); i += 2 {
+				lookup[id.flatTags[i]] = id.flatTags[i+1]
+			}
+
 			for _, k := range keys {
-				v := id.tags[k]
+				v := lookup[k]
 				_, err = buf.WriteRune('|')
 				if err != nil {
 					return errKey
@@ -80,35 +108,49 @@ func (id *Id) MapKey() string {
 // NewId generates a new *Id from the metric name, and the tags you want to
 // include on your metric.
 func NewId(name string, tags map[string]string) *Id {
-	myTags := make(map[string]string)
-	for k, v := range tags {
-		myTags[k] = v
+	var flat []string
+	if len(tags) > 0 {
+		flat = make([]string, 0, 2*len(tags))
+		for k, v := range tags {
+			flat = append(flat, k, v)
+		}
 	}
-
-	spectatorId := toSpectatorId(name, tags)
 
 	return &Id{
 		name:         name,
-		tags:         myTags,
-		spectatordId: spectatorId,
+		flatTags:     flat,
+		spectatordId: toSpectatorIdFromFlat(name, flat),
+	}
+}
+
+// newIdFromFlat creates an *Id directly from a pre-built flat tag slice,
+// avoiding an intermediate map allocation. Used by WithTag and WithTags.
+func newIdFromFlat(name string, flatTags []string) *Id {
+	return &Id{
+		name:         name,
+		flatTags:     flatTags,
+		spectatordId: toSpectatorIdFromFlat(name, flatTags),
 	}
 }
 
 // WithTag creates a deep copy of the *Id, adding the requested tag to the
 // internal collection.
 func (id *Id) WithTag(key string, value string) *Id {
-	newTags := make(map[string]string)
+	newFlat := make([]string, len(id.flatTags))
+	copy(newFlat, id.flatTags)
 
-	for k, v := range id.tags {
-		newTags[k] = v
+	for i := 0; i < len(id.flatTags); i += 2 {
+		if id.flatTags[i] == key {
+			newFlat[i+1] = value
+			return newIdFromFlat(id.name, newFlat)
+		}
 	}
-	newTags[key] = value
-
-	return NewId(id.name, newTags)
+	newFlat = append(newFlat, key, value)
+	return newIdFromFlat(id.name, newFlat)
 }
 
 func (id *Id) String() string {
-	return fmt.Sprintf("Id{name=%s,tags=%v}", id.name, id.tags)
+	return fmt.Sprintf("Id{name=%s,tags=%v}", id.name, id.Tags())
 }
 
 // Name exposes the internal metric name field.
@@ -116,10 +158,14 @@ func (id *Id) Name() string {
 	return id.name
 }
 
-// Tags directly exposes the internal tags map. This is not a copy of the map,
-// so any modifications to it will be observed by the *Id.
+// Tags returns a new map containing the identifier's tags. Each call allocates
+// a fresh map; mutating the returned map does not affect the *Id.
 func (id *Id) Tags() map[string]string {
-	return id.tags
+	m := make(map[string]string, len(id.flatTags)/2)
+	for i := 0; i+1 < len(id.flatTags); i += 2 {
+		m[id.flatTags[i]] = id.flatTags[i+1]
+	}
+	return m
 }
 
 // WithTags takes a map of tags, and returns a deep copy of *Id with the new
@@ -130,41 +176,59 @@ func (id *Id) WithTags(tags map[string]string) *Id {
 		return id
 	}
 
-	newTags := make(map[string]string)
-
-	for k, v := range id.tags {
-		newTags[k] = v
-	}
+	newFlat := make([]string, len(id.flatTags), len(id.flatTags)+2*len(tags))
+	copy(newFlat, id.flatTags)
 
 	for k, v := range tags {
-		newTags[k] = v
-	}
-	return NewId(id.name, newTags)
-}
-
-func toSpectatorId(name string, tags map[string]string) string {
-	var sb strings.Builder
-	writeSanitized(&sb, name)
-
-	// Append sanitized keys and values.
-	for k, v := range tags {
-		sb.WriteString(",")
-		writeSanitized(&sb, k)
-		sb.WriteString("=")
-		writeSanitized(&sb, v)
-	}
-
-	return sb.String()
-}
-
-func writeSanitized(sb *strings.Builder, input string) {
-	for _, r := range input {
-		if !isValidCharacter(r) {
-			sb.WriteRune('_')
-		} else {
-			sb.WriteRune(r)
+		updated := false
+		for i := 0; i < len(id.flatTags); i += 2 {
+			if id.flatTags[i] == k {
+				newFlat[i+1] = v
+				updated = true
+				break
+			}
+		}
+		if !updated {
+			newFlat = append(newFlat, k, v)
 		}
 	}
+	return newIdFromFlat(id.name, newFlat)
+}
+
+// toSpectatorIdFromFlat builds the spectatord line-protocol name from a flat
+// [k1, v1, k2, v2, ...] tag slice. Reuses a pooled buffer to avoid builder
+// growth allocations; the only allocation is the returned string.
+func toSpectatorIdFromFlat(name string, flatTags []string) string {
+	bp := spectatorIdBufPool.Get().(*[]byte)
+	b := (*bp)[:0]
+
+	b = appendSanitized(b, name)
+
+	for i := 0; i+1 < len(flatTags); i += 2 {
+		b = append(b, ',')
+		b = appendSanitized(b, flatTags[i])
+		b = append(b, '=')
+		b = appendSanitized(b, flatTags[i+1])
+	}
+
+	result := string(b)
+	*bp = b
+	spectatorIdBufPool.Put(bp)
+	return result
+}
+
+// appendSanitized appends the sanitized form of input to dst and returns the
+// extended slice. Every rune that passes isValidCharacter (all ASCII single-byte)
+// is appended directly; invalid runes become '_'.
+func appendSanitized(dst []byte, input string) []byte {
+	for _, r := range input {
+		if isValidCharacter(r) {
+			dst = append(dst, byte(r))
+		} else {
+			dst = append(dst, '_')
+		}
+	}
+	return dst
 }
 
 func isValidCharacter(r rune) bool {

--- a/spectator/meter/id.go
+++ b/spectator/meter/id.go
@@ -7,13 +7,64 @@ import (
 	"sync"
 )
 
+type tagPair struct {
+	key   string
+	value string
+}
+
+type tagPairs []tagPair
+
+func newTagPairs(tags map[string]string) tagPairs {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	flat := make(tagPairs, 0, len(tags))
+	for k, v := range tags {
+		flat = append(flat, tagPair{key: k, value: v})
+	}
+	return flat
+}
+
+func (tags tagPairs) clone(extraPairs int) tagPairs {
+	cloned := make(tagPairs, len(tags), len(tags)+extraPairs)
+	copy(cloned, tags)
+	return cloned
+}
+
+func (tags tagPairs) upsert(key string, value string) tagPairs {
+	for i := range tags {
+		if tags[i].key == key {
+			tags[i].value = value
+			return tags
+		}
+	}
+	return append(tags, tagPair{key: key, value: value})
+}
+
+func (tags tagPairs) sorted() []tagPair {
+	pairs := make([]tagPair, len(tags))
+	copy(pairs, tags)
+	sort.Slice(pairs, func(i int, j int) bool {
+		return pairs[i].key < pairs[j].key
+	})
+	return pairs
+}
+
+func (tags tagPairs) toMap() map[string]string {
+	m := make(map[string]string, len(tags))
+	for i := range tags {
+		m[tags[i].key] = tags[i].value
+	}
+	return m
+}
+
 // Id represents a meter's identifying information and dimensions (tags).
 type Id struct {
 	name string
-	// flatTags stores tags as a flat [k1, v1, k2, v2, ...] slice.
-	// This avoids the two allocations (hmap header + initial bucket) that a
-	// map[string]string would require when the map escapes to the heap.
-	flatTags []string
+	// tags stores key/value pairs in a slice to avoid the allocation overhead
+	// of a map while keeping the representation explicit.
+	tags tagPairs
 	// keyOnce protects access to key, allowing it to be computed on demand
 	// without racing other readers.
 	keyOnce sync.Once
@@ -50,33 +101,17 @@ func (id *Id) MapKey() string {
 				return errKey
 			}
 
-			n := len(id.flatTags) / 2
-			if n == 0 {
+			pairs := id.tags.sorted()
+			if len(pairs) == 0 {
 				return buf.String()
 			}
 
-			// Extract keys for sorting
-			keys := make([]string, 0, n)
-			for i := 0; i+1 < len(id.flatTags); i += 2 {
-				keys = append(keys, id.flatTags[i])
-			}
-			sort.Strings(keys)
-
-			// Build a temporary map for O(1) value lookup during key emission.
-			// MapKey is called at most once per Id (result is cached), so this
-			// transient allocation is acceptable.
-			lookup := make(map[string]string, n)
-			for i := 0; i+1 < len(id.flatTags); i += 2 {
-				lookup[id.flatTags[i]] = id.flatTags[i+1]
-			}
-
-			for _, k := range keys {
-				v := lookup[k]
+			for i := range pairs {
 				_, err = buf.WriteRune('|')
 				if err != nil {
 					return errKey
 				}
-				_, err = buf.WriteString(k)
+				_, err = buf.WriteString(pairs[i].key)
 				if err != nil {
 					return errKey
 				}
@@ -84,7 +119,7 @@ func (id *Id) MapKey() string {
 				if err != nil {
 					return errKey
 				}
-				_, err = buf.WriteString(v)
+				_, err = buf.WriteString(pairs[i].value)
 				if err != nil {
 					return errKey
 				}
@@ -98,45 +133,30 @@ func (id *Id) MapKey() string {
 // NewId generates a new *Id from the metric name, and the tags you want to
 // include on your metric.
 func NewId(name string, tags map[string]string) *Id {
-	var flat []string
-	if len(tags) > 0 {
-		flat = make([]string, 0, 2*len(tags))
-		for k, v := range tags {
-			flat = append(flat, k, v)
-		}
-	}
+	pairs := newTagPairs(tags)
 
 	return &Id{
 		name:         name,
-		flatTags:     flat,
-		spectatordId: toSpectatorIdFromFlat(name, flat),
+		tags:         pairs,
+		spectatordId: toSpectatorIdFromPairs(name, pairs),
 	}
 }
 
-// newIdFromFlat creates an *Id directly from a pre-built flat tag slice,
+// newIdFromPairs creates an *Id directly from a pre-built tag slice,
 // avoiding an intermediate map allocation. Used by WithTag and WithTags.
-func newIdFromFlat(name string, flatTags []string) *Id {
+func newIdFromPairs(name string, tags tagPairs) *Id {
 	return &Id{
 		name:         name,
-		flatTags:     flatTags,
-		spectatordId: toSpectatorIdFromFlat(name, flatTags),
+		tags:         tags,
+		spectatordId: toSpectatorIdFromPairs(name, tags),
 	}
 }
 
 // WithTag creates a deep copy of the *Id, adding the requested tag to the
 // internal collection.
 func (id *Id) WithTag(key string, value string) *Id {
-	newFlat := make([]string, len(id.flatTags))
-	copy(newFlat, id.flatTags)
-
-	for i := 0; i < len(id.flatTags); i += 2 {
-		if id.flatTags[i] == key {
-			newFlat[i+1] = value
-			return newIdFromFlat(id.name, newFlat)
-		}
-	}
-	newFlat = append(newFlat, key, value)
-	return newIdFromFlat(id.name, newFlat)
+	newTags := id.tags.clone(1).upsert(key, value)
+	return newIdFromPairs(id.name, newTags)
 }
 
 func (id *Id) String() string {
@@ -151,11 +171,7 @@ func (id *Id) Name() string {
 // Tags returns a new map containing the identifier's tags. Each call allocates
 // a fresh map; mutating the returned map does not affect the *Id.
 func (id *Id) Tags() map[string]string {
-	m := make(map[string]string, len(id.flatTags)/2)
-	for i := 0; i+1 < len(id.flatTags); i += 2 {
-		m[id.flatTags[i]] = id.flatTags[i+1]
-	}
-	return m
+	return id.tags.toMap()
 }
 
 // WithTags takes a map of tags, and returns a deep copy of *Id with the new
@@ -166,39 +182,27 @@ func (id *Id) WithTags(tags map[string]string) *Id {
 		return id
 	}
 
-	newFlat := make([]string, len(id.flatTags), len(id.flatTags)+2*len(tags))
-	copy(newFlat, id.flatTags)
-
+	newTags := id.tags.clone(len(tags))
 	for k, v := range tags {
-		updated := false
-		for i := 0; i < len(id.flatTags); i += 2 {
-			if id.flatTags[i] == k {
-				newFlat[i+1] = v
-				updated = true
-				break
-			}
-		}
-		if !updated {
-			newFlat = append(newFlat, k, v)
-		}
+		newTags = newTags.upsert(k, v)
 	}
-	return newIdFromFlat(id.name, newFlat)
+	return newIdFromPairs(id.name, newTags)
 }
 
-// toSpectatorIdFromFlat builds the spectatord line-protocol name from a flat
-// [k1, v1, k2, v2, ...] tag slice. Reuses a pooled buffer to avoid builder
+// toSpectatorIdFromPairs builds the spectatord line-protocol name from tag
+// pairs. Reuses a pooled buffer to avoid builder
 // growth allocations; the only allocation is the returned string.
-func toSpectatorIdFromFlat(name string, flatTags []string) string {
+func toSpectatorIdFromPairs(name string, tags tagPairs) string {
 	bp := byteBufPool.Get().(*[]byte)
 	b := (*bp)[:0]
 
 	b = appendSanitized(b, name)
 
-	for i := 0; i+1 < len(flatTags); i += 2 {
+	for i := range tags {
 		b = append(b, ',')
-		b = appendSanitized(b, flatTags[i])
+		b = appendSanitized(b, tags[i].key)
 		b = append(b, '=')
-		b = appendSanitized(b, flatTags[i+1])
+		b = appendSanitized(b, tags[i].value)
 	}
 
 	result := string(b)

--- a/spectator/meter/id.go
+++ b/spectator/meter/id.go
@@ -28,16 +28,6 @@ var builderPool = sync.Pool{
 	},
 }
 
-// spectatorIdBufPool holds reusable byte-slice buffers for toSpectatorIdFromFlat.
-// Using *[]byte (not strings.Builder) so we can preserve capacity across calls
-// by resetting to len=0 without clearing the backing array.
-var spectatorIdBufPool = sync.Pool{
-	New: func() interface{} {
-		b := make([]byte, 0, 256)
-		return &b
-	},
-}
-
 // MapKey computes and saves a key within the struct to be used to uniquely
 // identify this *Id in a map. This does use the information from within the
 // *Id, so it assumes you've not accidentally double-declared this *Id.
@@ -199,7 +189,7 @@ func (id *Id) WithTags(tags map[string]string) *Id {
 // [k1, v1, k2, v2, ...] tag slice. Reuses a pooled buffer to avoid builder
 // growth allocations; the only allocation is the returned string.
 func toSpectatorIdFromFlat(name string, flatTags []string) string {
-	bp := spectatorIdBufPool.Get().(*[]byte)
+	bp := byteBufPool.Get().(*[]byte)
 	b := (*bp)[:0]
 
 	b = appendSanitized(b, name)
@@ -213,7 +203,7 @@ func toSpectatorIdFromFlat(name string, flatTags []string) string {
 
 	result := string(b)
 	*bp = b
-	spectatorIdBufPool.Put(bp)
+	byteBufPool.Put(bp)
 	return result
 }
 

--- a/spectator/meter/id_test.go
+++ b/spectator/meter/id_test.go
@@ -100,48 +100,86 @@ func TestId_WithTags(t *testing.T) {
 	}
 }
 
-func TestToSpectatorId(t *testing.T) {
-	name := "test"
-	tags := map[string]string{
-		"tag1": "value1",
-		"tag2": "value2",
+func TestId_WithTag(t *testing.T) {
+	tests := map[string]struct {
+		baseTags     map[string]string
+		key          string
+		value        string
+		expectedTags map[string]string
+	}{
+		"add new key": {
+			baseTags:     map[string]string{"a": "1"},
+			key:          "b",
+			value:        "2",
+			expectedTags: map[string]string{"a": "1", "b": "2"},
+		},
+		"replace existing key": {
+			baseTags:     map[string]string{"a": "1", "b": "2"},
+			key:          "a",
+			value:        "replaced",
+			expectedTags: map[string]string{"a": "replaced", "b": "2"},
+		},
+		"no existing tags": {
+			baseTags:     nil,
+			key:          "a",
+			value:        "1",
+			expectedTags: map[string]string{"a": "1"},
+		},
 	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			id := NewId("foo", tt.baseTags)
+			id2 := id.WithTag(tt.key, tt.value)
 
-	// The order of the tags is not guaranteed
-	expected1 := "test,tag1=value1,tag2=value2"
-	expected2 := "test,tag2=value2,tag1=value1"
-	result := toSpectatorId(name, tags)
-
-	if result != expected1 && result != expected2 {
-		t.Errorf("Expected '%s' or '%s', got '%s'", expected1, expected2, result)
+			if !reflect.DeepEqual(tt.expectedTags, id2.Tags()) {
+				t.Errorf("Expected %v, got %v", tt.expectedTags, id2.Tags())
+			}
+		})
 	}
 }
 
-func TestToSpectatorId_EmptyTags(t *testing.T) {
-	name := "test"
-	tags := map[string]string{}
+func TestId_WithTag_DoesNotMutateOriginal(t *testing.T) {
+	id := NewId("foo", map[string]string{"a": "1"})
+	_ = id.WithTag("b", "2")
 
-	expected := "test"
-	result := toSpectatorId(name, tags)
+	expected := map[string]string{"a": "1"}
+	if !reflect.DeepEqual(expected, id.Tags()) {
+		t.Errorf("Original mutated: expected %v, got %v", expected, id.Tags())
+	}
+}
 
+func TestToSpectatorIdFromFlat_InvalidTags(t *testing.T) {
+	name := "test`!@#$%^&*()-=~_+[]{}\\|;:'\",<.>/?foo"
+	flat := []string{"tag1,:=", "value1,:=", "tag2,;=", "value2,;="}
+	result := toSpectatorIdFromFlat(name, flat)
+
+	// Tags appear in insertion order (flat slice), so order is deterministic.
+	expected := "test______^____-_~______________.___foo,tag1___=value1___,tag2___=value2___"
 	if result != expected {
 		t.Errorf("Expected '%s', got '%s'", expected, result)
 	}
 }
 
-func TestToSpectatorId_InvalidTags(t *testing.T) {
-	name := "test`!@#$%^&*()-=~_+[]{}\\|;:'\",<.>/?foo"
-	tags := map[string]string{
-		"tag1,:=": "value1,:=",
-		"tag2,;=": "value2,;=",
+func TestToSpectatorIdFromFlat(t *testing.T) {
+	tests := map[string]struct {
+		metric   string
+		flatTags []string
+		expected string
+	}{
+		"no tags":        {metric: "test", flatTags: nil, expected: "test"},
+		"empty tags":     {metric: "test", flatTags: []string{}, expected: "test"},
+		"one tag":        {metric: "test", flatTags: []string{"k1", "v1"}, expected: "test,k1=v1"},
+		"two tags":       {metric: "test", flatTags: []string{"k1", "v1", "k2", "v2"}, expected: "test,k1=v1,k2=v2"},
+		"sanitized name": {metric: "test!@#", flatTags: nil, expected: "test___"},
+		"sanitized tags": {metric: "test", flatTags: []string{"k!ey", "v@lue"}, expected: "test,k_ey=v_lue"},
 	}
-
-	expected1 := "test______^____-_~______________.___foo,tag1___=value1___,tag2___=value2___"
-	expected2 := "test______^____-_~______________.___foo,tag2___=value2___,tag1___=value1___"
-	result := toSpectatorId(name, tags)
-
-	if result != expected1 && result != expected2 {
-		t.Errorf("Expected '%s' or '%s', got '%s'", expected1, expected2, result)
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := toSpectatorIdFromFlat(tt.metric, tt.flatTags)
+			if result != tt.expected {
+				t.Errorf("Expected '%s', got '%s'", tt.expected, result)
+			}
+		})
 	}
 }
 
@@ -186,9 +224,14 @@ func BenchmarkToSpectatorId(b *testing.B) {
 	}
 }
 
-func BenchmarkToSpectatorIdBuilder(b *testing.B) {
+func BenchmarkToSpectatorIdFromFlat(b *testing.B) {
+	flat := make([]string, 0, 2*len(benchTags))
+	for k, v := range benchTags {
+		flat = append(flat, k, v)
+	}
 	b.ReportAllocs()
+	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		_ = toSpectatorId(benchName, benchTags)
+		_ = toSpectatorIdFromFlat(benchName, flat)
 	}
 }

--- a/spectator/meter/id_test.go
+++ b/spectator/meter/id_test.go
@@ -100,6 +100,127 @@ func TestId_WithTags(t *testing.T) {
 	}
 }
 
+func TestTagPairs_clone(t *testing.T) {
+	tests := map[string]struct {
+		input      tagPairs
+		extraPairs int
+		wantLen    int
+		wantCap    int
+	}{
+		"nil":            {input: nil, extraPairs: 0, wantLen: 0, wantCap: 0},
+		"empty":          {input: tagPairs{}, extraPairs: 0, wantLen: 0, wantCap: 0},
+		"extra capacity": {input: tagPairs{{key: "a", value: "1"}}, extraPairs: 3, wantLen: 1, wantCap: 4},
+		"zero extra":     {input: tagPairs{{key: "a", value: "1"}}, extraPairs: 0, wantLen: 1, wantCap: 1},
+		"multiple":       {input: tagPairs{{key: "a", value: "1"}, {key: "b", value: "2"}}, extraPairs: 1, wantLen: 2, wantCap: 3},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			cloned := tt.input.clone(tt.extraPairs)
+			if len(cloned) != tt.wantLen {
+				t.Errorf("len = %d, want %d", len(cloned), tt.wantLen)
+			}
+			if cap(cloned) != tt.wantCap {
+				t.Errorf("cap = %d, want %d", cap(cloned), tt.wantCap)
+			}
+		})
+	}
+}
+
+func TestTagPairs_clone_independent(t *testing.T) {
+	orig := tagPairs{{key: "a", value: "1"}}
+	cloned := orig.clone(0)
+	cloned[0].value = "changed"
+	if orig[0].value != "1" {
+		t.Errorf("clone mutated original: got %q, want %q", orig[0].value, "1")
+	}
+}
+
+func TestTagPairs_upsert(t *testing.T) {
+	tests := map[string]struct {
+		input    tagPairs
+		key      string
+		value    string
+		wantLen  int
+		wantTags map[string]string
+	}{
+		"nil append": {
+			input: nil, key: "a", value: "1",
+			wantLen: 1, wantTags: map[string]string{"a": "1"},
+		},
+		"empty append": {
+			input: tagPairs{}, key: "a", value: "1",
+			wantLen: 1, wantTags: map[string]string{"a": "1"},
+		},
+		"append new": {
+			input: tagPairs{{key: "a", value: "1"}}, key: "b", value: "2",
+			wantLen: 2, wantTags: map[string]string{"a": "1", "b": "2"},
+		},
+		"update existing": {
+			input: tagPairs{{key: "a", value: "1"}, {key: "b", value: "2"}}, key: "a", value: "replaced",
+			wantLen: 2, wantTags: map[string]string{"a": "replaced", "b": "2"},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := tt.input.upsert(tt.key, tt.value)
+			if len(result) != tt.wantLen {
+				t.Errorf("len = %d, want %d", len(result), tt.wantLen)
+			}
+			if got := result.toMap(); !reflect.DeepEqual(got, tt.wantTags) {
+				t.Errorf("toMap = %v, want %v", got, tt.wantTags)
+			}
+		})
+	}
+}
+
+func TestTagPairs_sorted(t *testing.T) {
+	tests := map[string]struct {
+		input tagPairs
+		want  []tagPair
+	}{
+		"nil":      {input: nil, want: []tagPair{}},
+		"empty":    {input: tagPairs{}, want: []tagPair{}},
+		"single":   {input: tagPairs{{key: "a", value: "1"}}, want: []tagPair{{key: "a", value: "1"}}},
+		"reversed": {input: tagPairs{{key: "c", value: "3"}, {key: "a", value: "1"}, {key: "b", value: "2"}}, want: []tagPair{{key: "a", value: "1"}, {key: "b", value: "2"}, {key: "c", value: "3"}}},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := tt.input.sorted()
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("sorted = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTagPairs_sorted_does_not_mutate(t *testing.T) {
+	orig := tagPairs{{key: "c", value: "3"}, {key: "a", value: "1"}}
+	_ = orig.sorted()
+	if orig[0].key != "c" {
+		t.Errorf("sorted mutated original: first key = %q, want %q", orig[0].key, "c")
+	}
+}
+
+func TestTagPairs_toMap(t *testing.T) {
+	tests := map[string]struct {
+		input tagPairs
+		want  map[string]string
+	}{
+		"nil":      {input: nil, want: map[string]string{}},
+		"empty":    {input: tagPairs{}, want: map[string]string{}},
+		"single":   {input: tagPairs{{key: "a", value: "1"}}, want: map[string]string{"a": "1"}},
+		"multiple": {input: tagPairs{{key: "a", value: "1"}, {key: "b", value: "2"}}, want: map[string]string{"a": "1", "b": "2"}},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := tt.input.toMap()
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("toMap = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestId_WithTag(t *testing.T) {
 	tests := map[string]struct {
 		baseTags     map[string]string
@@ -148,40 +269,45 @@ func TestId_WithTag_DoesNotMutateOriginal(t *testing.T) {
 	}
 }
 
-func TestToSpectatorIdFromFlat_InvalidTags(t *testing.T) {
+func TestToSpectatorIdFromPairs_InvalidTags(t *testing.T) {
 	name := "test`!@#$%^&*()-=~_+[]{}\\|;:'\",<.>/?foo"
-	flat := []string{"tag1,:=", "value1,:=", "tag2,;=", "value2,;="}
-	result := toSpectatorIdFromFlat(name, flat)
+	tags := tagPairs{
+		{key: "tag1,:=", value: "value1,:="},
+		{key: "tag2,;=", value: "value2,;="},
+	}
+	result := toSpectatorIdFromPairs(name, tags)
 
-	// Tags appear in insertion order (flat slice), so order is deterministic.
+	// Tags appear in insertion order, so order is deterministic.
 	expected := "test______^____-_~______________.___foo,tag1___=value1___,tag2___=value2___"
 	if result != expected {
 		t.Errorf("Expected '%s', got '%s'", expected, result)
 	}
 }
 
-func TestToSpectatorIdFromFlat(t *testing.T) {
+func TestToSpectatorIdFromPairs(t *testing.T) {
 	tests := map[string]struct {
 		metric   string
-		flatTags []string
+		tags     tagPairs
 		expected string
 	}{
-		"no tags":        {metric: "test", flatTags: nil, expected: "test"},
-		"empty tags":     {metric: "test", flatTags: []string{}, expected: "test"},
-		"one tag":        {metric: "test", flatTags: []string{"k1", "v1"}, expected: "test,k1=v1"},
-		"two tags":       {metric: "test", flatTags: []string{"k1", "v1", "k2", "v2"}, expected: "test,k1=v1,k2=v2"},
-		"sanitized name": {metric: "test!@#", flatTags: nil, expected: "test___"},
-		"sanitized tags": {metric: "test", flatTags: []string{"k!ey", "v@lue"}, expected: "test,k_ey=v_lue"},
+		"no tags":        {metric: "test", tags: nil, expected: "test"},
+		"empty tags":     {metric: "test", tags: tagPairs{}, expected: "test"},
+		"one tag":        {metric: "test", tags: tagPairs{{key: "k1", value: "v1"}}, expected: "test,k1=v1"},
+		"two tags":       {metric: "test", tags: tagPairs{{key: "k1", value: "v1"}, {key: "k2", value: "v2"}}, expected: "test,k1=v1,k2=v2"},
+		"sanitized name": {metric: "test!@#", tags: nil, expected: "test___"},
+		"sanitized tags": {metric: "test", tags: tagPairs{{key: "k!ey", value: "v@lue"}}, expected: "test,k_ey=v_lue"},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			result := toSpectatorIdFromFlat(tt.metric, tt.flatTags)
+			result := toSpectatorIdFromPairs(tt.metric, tt.tags)
 			if result != tt.expected {
 				t.Errorf("Expected '%s', got '%s'", tt.expected, result)
 			}
 		})
 	}
 }
+
+var benchSinkString string
 
 var benchName = "my.metric.with_a_fairly_long_name.and.some.invalid.chars!@#"
 var benchTags = map[string]string{
@@ -220,18 +346,18 @@ func BenchmarkToSpectatorId(b *testing.B) {
 
 	b.ReportAllocs()
 	for n := 0; n < b.N; n++ {
-		_ = originalToSpectatorId(benchName, benchTags)
+		benchSinkString = originalToSpectatorId(benchName, benchTags)
 	}
 }
 
-func BenchmarkToSpectatorIdFromFlat(b *testing.B) {
-	flat := make([]string, 0, 2*len(benchTags))
+func BenchmarkToSpectatorIdFromPairs(b *testing.B) {
+	tags := make(tagPairs, 0, len(benchTags))
 	for k, v := range benchTags {
-		flat = append(flat, k, v)
+		tags = append(tags, tagPair{key: k, value: v})
 	}
 	b.ReportAllocs()
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		_ = toSpectatorIdFromFlat(benchName, flat)
+		benchSinkString = toSpectatorIdFromPairs(benchName, tags)
 	}
 }

--- a/spectator/meter/line_protocol.go
+++ b/spectator/meter/line_protocol.go
@@ -18,15 +18,21 @@ var byteBufPool = sync.Pool{
 	},
 }
 
+func appendLinePrefix(dst []byte, symbol string, spectatordId string) []byte {
+	dst = append(dst, symbol...)
+	dst = append(dst, ':')
+	dst = append(dst, spectatordId...)
+	dst = append(dst, ':')
+	return dst
+}
+
 // writeLineInt writes "symbol:spectatordId:val" to w using a pooled buffer,
 // replacing fmt.Sprintf("%s:%s:%d", ...) with zero-alloc integer formatting.
 func writeLineInt(w writer.Writer, symbol string, spectatordId string, val int64) {
 	bp := byteBufPool.Get().(*[]byte)
-	b := append((*bp)[:0], symbol...)
-	b = append(b, ':')
-	b = append(b, spectatordId...)
-	b = append(b, ':')
+	b := appendLinePrefix((*bp)[:0], symbol, spectatordId)
 	b = strconv.AppendInt(b, val, 10)
+	// Use Write to preserve buffering behavior in wrapped writers.
 	w.Write(string(b))
 	*bp = b
 	byteBufPool.Put(bp)
@@ -36,11 +42,9 @@ func writeLineInt(w writer.Writer, symbol string, spectatordId string, val int64
 // replacing fmt.Sprintf("%s:%s:%f", ...) with zero-alloc float formatting.
 func writeLineFloat(w writer.Writer, symbol string, spectatordId string, val float64) {
 	bp := byteBufPool.Get().(*[]byte)
-	b := append((*bp)[:0], symbol...)
-	b = append(b, ':')
-	b = append(b, spectatordId...)
-	b = append(b, ':')
+	b := appendLinePrefix((*bp)[:0], symbol, spectatordId)
 	b = strconv.AppendFloat(b, val, 'f', 6, 64)
+	// Use Write to preserve buffering behavior in wrapped writers.
 	w.Write(string(b))
 	*bp = b
 	byteBufPool.Put(bp)
@@ -50,11 +54,9 @@ func writeLineFloat(w writer.Writer, symbol string, spectatordId string, val flo
 // replacing fmt.Sprintf("%s:%s:%d", ...) with zero-alloc uint formatting.
 func writeLineUint(w writer.Writer, symbol string, spectatordId string, val uint64) {
 	bp := byteBufPool.Get().(*[]byte)
-	b := append((*bp)[:0], symbol...)
-	b = append(b, ':')
-	b = append(b, spectatordId...)
-	b = append(b, ':')
+	b := appendLinePrefix((*bp)[:0], symbol, spectatordId)
 	b = strconv.AppendUint(b, val, 10)
+	// Use Write to preserve buffering behavior in wrapped writers.
 	w.Write(string(b))
 	*bp = b
 	byteBufPool.Put(bp)

--- a/spectator/meter/line_protocol.go
+++ b/spectator/meter/line_protocol.go
@@ -1,0 +1,61 @@
+package meter
+
+import (
+	"strconv"
+	"sync"
+
+	"github.com/Netflix/spectator-go/v2/spectator/writer"
+)
+
+// byteBufPool holds reusable byte-slice buffers for building spectatord
+// protocol strings (both line-protocol values and spectator IDs), avoiding
+// fmt.Sprintf boxing overhead. Using *[]byte so we can preserve capacity
+// across calls by resetting to len=0 without clearing the backing array.
+var byteBufPool = sync.Pool{
+	New: func() interface{} {
+		b := make([]byte, 0, 256)
+		return &b
+	},
+}
+
+// writeLineInt writes "symbol:spectatordId:val" to w using a pooled buffer,
+// replacing fmt.Sprintf("%s:%s:%d", ...) with zero-alloc integer formatting.
+func writeLineInt(w writer.Writer, symbol string, spectatordId string, val int64) {
+	bp := byteBufPool.Get().(*[]byte)
+	b := append((*bp)[:0], symbol...)
+	b = append(b, ':')
+	b = append(b, spectatordId...)
+	b = append(b, ':')
+	b = strconv.AppendInt(b, val, 10)
+	w.Write(string(b))
+	*bp = b
+	byteBufPool.Put(bp)
+}
+
+// writeLineFloat writes "symbol:spectatordId:val" to w using a pooled buffer,
+// replacing fmt.Sprintf("%s:%s:%f", ...) with zero-alloc float formatting.
+func writeLineFloat(w writer.Writer, symbol string, spectatordId string, val float64) {
+	bp := byteBufPool.Get().(*[]byte)
+	b := append((*bp)[:0], symbol...)
+	b = append(b, ':')
+	b = append(b, spectatordId...)
+	b = append(b, ':')
+	b = strconv.AppendFloat(b, val, 'f', 6, 64)
+	w.Write(string(b))
+	*bp = b
+	byteBufPool.Put(bp)
+}
+
+// writeLineUint writes "symbol:spectatordId:val" to w using a pooled buffer,
+// replacing fmt.Sprintf("%s:%s:%d", ...) with zero-alloc uint formatting.
+func writeLineUint(w writer.Writer, symbol string, spectatordId string, val uint64) {
+	bp := byteBufPool.Get().(*[]byte)
+	b := append((*bp)[:0], symbol...)
+	b = append(b, ':')
+	b = append(b, spectatordId...)
+	b = append(b, ':')
+	b = strconv.AppendUint(b, val, 10)
+	w.Write(string(b))
+	*bp = b
+	byteBufPool.Put(bp)
+}

--- a/spectator/meter/line_protocol_test.go
+++ b/spectator/meter/line_protocol_test.go
@@ -1,0 +1,81 @@
+package meter
+
+import (
+	"math"
+	"testing"
+
+	"github.com/Netflix/spectator-go/v2/spectator/writer"
+)
+
+func TestWriteLineInt(t *testing.T) {
+	tests := map[string]struct {
+		symbol   string
+		spectId  string
+		val      int64
+		expected string
+	}{
+		"zero":      {symbol: "c", spectId: "name", val: 0, expected: "c:name:0"},
+		"positive":  {symbol: "c", spectId: "name", val: 42, expected: "c:name:42"},
+		"negative":  {symbol: "c", spectId: "name", val: -1, expected: "c:name:-1"},
+		"max_int64": {symbol: "c", spectId: "name", val: math.MaxInt64, expected: "c:name:9223372036854775807"},
+		"min_int64": {symbol: "c", spectId: "name", val: math.MinInt64, expected: "c:name:-9223372036854775808"},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			w := writer.MemoryWriter{}
+			writeLineInt(&w, tt.symbol, tt.spectId, tt.val)
+			if got := w.Lines()[0]; got != tt.expected {
+				t.Errorf("Expected line to be %s, got %s", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestWriteLineFloat(t *testing.T) {
+	tests := map[string]struct {
+		symbol   string
+		spectId  string
+		val      float64
+		expected string
+	}{
+		"zero":                {symbol: "g", spectId: "name", val: 0.0, expected: "g:name:0.000000"},
+		"positive":            {symbol: "g", spectId: "name", val: 100.1, expected: "g:name:100.100000"},
+		"negative":            {symbol: "g", spectId: "name", val: -100.1, expected: "g:name:-100.100000"},
+		"tiny_rounds_to_zero": {symbol: "g", spectId: "name", val: 1e-7, expected: "g:name:0.000000"},
+		"large":               {symbol: "g", spectId: "name", val: 1e15, expected: "g:name:1000000000000000.000000"},
+		"nan":                 {symbol: "g", spectId: "name", val: math.NaN(), expected: "g:name:NaN"},
+		"positive_inf":        {symbol: "g", spectId: "name", val: math.Inf(1), expected: "g:name:+Inf"},
+		"negative_inf":        {symbol: "g", spectId: "name", val: math.Inf(-1), expected: "g:name:-Inf"},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			w := writer.MemoryWriter{}
+			writeLineFloat(&w, tt.symbol, tt.spectId, tt.val)
+			if got := w.Lines()[0]; got != tt.expected {
+				t.Errorf("Expected line to be %s, got %s", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestWriteLineUint(t *testing.T) {
+	tests := map[string]struct {
+		symbol   string
+		spectId  string
+		val      uint64
+		expected string
+	}{
+		"zero":       {symbol: "U", spectId: "name", val: 0, expected: "U:name:0"},
+		"positive":   {symbol: "U", spectId: "name", val: 42, expected: "U:name:42"},
+		"max_uint64": {symbol: "U", spectId: "name", val: math.MaxUint64, expected: "U:name:18446744073709551615"},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			w := writer.MemoryWriter{}
+			writeLineUint(&w, tt.symbol, tt.spectId, tt.val)
+			if got := w.Lines()[0]; got != tt.expected {
+				t.Errorf("Expected line to be %s, got %s", tt.expected, got)
+			}
+		})
+	}
+}

--- a/spectator/meter/max_gauge.go
+++ b/spectator/meter/max_gauge.go
@@ -1,7 +1,6 @@
 package meter
 
 import (
-	"fmt"
 	"github.com/Netflix/spectator-go/v2/spectator/writer"
 )
 
@@ -31,6 +30,5 @@ func (g *MaxGauge) MeterId() *Id {
 
 // Set records the current value.
 func (g *MaxGauge) Set(value float64) {
-	var line = fmt.Sprintf("%s:%s:%f", g.meterTypeSymbol, g.id.spectatordId, value)
-	g.writer.Write(line)
+	writeLineFloat(g.writer, g.meterTypeSymbol, g.id.spectatordId, value)
 }

--- a/spectator/meter/monotonic_counter.go
+++ b/spectator/meter/monotonic_counter.go
@@ -1,7 +1,6 @@
 package meter
 
 import (
-	"fmt"
 	"github.com/Netflix/spectator-go/v2/spectator/writer"
 )
 
@@ -35,6 +34,5 @@ func (c *MonotonicCounter) MeterId() *Id {
 
 // Set sets a value as the current measurement; spectatord calculates the delta.
 func (c *MonotonicCounter) Set(value float64) {
-	var line = fmt.Sprintf("%s:%s:%f", c.meterTypeSymbol, c.id.spectatordId, value)
-	c.writer.Write(line)
+	writeLineFloat(c.writer, c.meterTypeSymbol, c.id.spectatordId, value)
 }

--- a/spectator/meter/monotonic_counter_uint.go
+++ b/spectator/meter/monotonic_counter_uint.go
@@ -1,7 +1,6 @@
 package meter
 
 import (
-	"fmt"
 	"github.com/Netflix/spectator-go/v2/spectator/writer"
 )
 
@@ -35,6 +34,5 @@ func (c *MonotonicCounterUint) MeterId() *Id {
 
 // Set sets a value as the current measurement; spectatord calculates the delta.
 func (c *MonotonicCounterUint) Set(value uint64) {
-	var line = fmt.Sprintf("%s:%s:%d", c.meterTypeSymbol, c.id.spectatordId, value)
-	c.writer.Write(line)
+	writeLineUint(c.writer, c.meterTypeSymbol, c.id.spectatordId, value)
 }

--- a/spectator/meter/percentile_distsummary.go
+++ b/spectator/meter/percentile_distsummary.go
@@ -1,7 +1,6 @@
 package meter
 
 import (
-	"fmt"
 	"github.com/Netflix/spectator-go/v2/spectator/writer"
 )
 
@@ -25,7 +24,6 @@ func NewPercentileDistributionSummary(id *Id, writer writer.Writer) *PercentileD
 // Record records an amount to track within the distribution.
 func (p *PercentileDistributionSummary) Record(amount int64) {
 	if amount >= 0 {
-		var line = fmt.Sprintf("%s:%s:%d", p.meterTypeSymbol, p.id.spectatordId, amount)
-		p.writer.Write(line)
+		writeLineInt(p.writer, p.meterTypeSymbol, p.id.spectatordId, amount)
 	}
 }

--- a/spectator/meter/percentile_timer.go
+++ b/spectator/meter/percentile_timer.go
@@ -1,9 +1,9 @@
 package meter
 
 import (
-	"fmt"
-	"github.com/Netflix/spectator-go/v2/spectator/writer"
 	"time"
+
+	"github.com/Netflix/spectator-go/v2/spectator/writer"
 )
 
 // PercentileTimer represents timing events, while capturing the histogram
@@ -28,7 +28,6 @@ func (t *PercentileTimer) MeterId() *Id {
 // Record records the value for a single event.
 func (t *PercentileTimer) Record(amount time.Duration) {
 	if amount >= 0 {
-		var line = fmt.Sprintf("%s:%s:%f", t.meterTypeSymbol, t.id.spectatordId, amount.Seconds())
-		t.writer.Write(line)
+		writeLineFloat(t.writer, t.meterTypeSymbol, t.id.spectatordId, amount.Seconds())
 	}
 }

--- a/spectator/meter/timer.go
+++ b/spectator/meter/timer.go
@@ -1,9 +1,9 @@
 package meter
 
 import (
-	"fmt"
-	"github.com/Netflix/spectator-go/v2/spectator/writer"
 	"time"
+
+	"github.com/Netflix/spectator-go/v2/spectator/writer"
 )
 
 // Timer is used to measure how long (in seconds) some event is taking. This
@@ -27,7 +27,6 @@ func (t *Timer) MeterId() *Id {
 // Record records the duration this specific event took.
 func (t *Timer) Record(amount time.Duration) {
 	if amount >= 0 {
-		var line = fmt.Sprintf("%s:%s:%f", t.meterTypeSymbol, t.id.spectatordId, amount.Seconds())
-		t.writer.Write(line)
+		writeLineFloat(t.writer, t.meterTypeSymbol, t.id.spectatordId, amount.Seconds())
 	}
 }


### PR DESCRIPTION
## Summary
- Reduce `meter.Id` construction overhead by replacing escaped tag maps with a lower-allocation internal representation and pooling spectatord id formatting buffers
- Replace per-meter `fmt.Sprintf` line construction with pooled `strconv.Append*` helpers shared across meter types
- Keep the follow-up readability cleanup separate while preserving the large runtime and allocation win versus `main`

## Benchstat
Against `main` using the same temporary benchmark harness for both trees (`-count=10 -cpu 1`) on `darwin/arm64` (`Apple M3 Pro`):

Time:

| Benchmark | main | current PR | vs base |
| --- | ---: | ---: | ---: |
| `NewId` | `1269.0ns` | `392.5ns` | `-69.07%` |
| `CombinedBenchmark` | `1366.5ns` | `433.2ns` | `-68.30%` |

Bytes:

| Benchmark | main | current PR | vs base |
| --- | ---: | ---: | ---: |
| `NewId B/op` | `920` | `432` | `-53.04%` |
| `CombinedBenchmark B/op` | `1128` | `608` | `-46.10%` |

Allocations:

| Benchmark | main | current PR | vs base |
| --- | ---: | ---: | ---: |
| `NewId allocs` | `9` | `3` | `-66.67%` |
| `CombinedBenchmark allocs` | `12` | `4` | `-66.67%` |

## Test plan
- [x] `go test ./spectator/meter ./spectator/writer`
- [x] targeted meter benchmarks for `NewId`, combined benchmark coverage, post-GC behavior, and spectatord id formatting during development
- [x] `benchstat` comparison against `main` showing substantial wins in wall-clock, bytes/op, and allocs/op