### PR TITLE
Reduce meter line formatting allocations

### DIFF
--- a/spectator/meter/age_gauge.go
+++ b/spectator/meter/age_gauge.go
@@ -1,7 +1,6 @@
 package meter
 
 import (
-	"fmt"
 	"github.com/Netflix/spectator-go/v2/spectator/writer"
 )
 
@@ -31,13 +30,11 @@ func (g *AgeGauge) MeterId() *Id {
 // Set records the current time in seconds since the epoch.
 func (g *AgeGauge) Set(seconds int64) {
 	if seconds >= 0 {
-		var line = fmt.Sprintf("%s:%s:%d", g.meterTypeSymbol, g.id.spectatordId, seconds)
-		g.writer.Write(line)
+		writeLineInt(g.writer, g.meterTypeSymbol, g.id.spectatordId, seconds)
 	}
 }
 
 // Now records the current time in epoch seconds, using a spectatord feature.
 func (g *AgeGauge) Now() {
-	var line = fmt.Sprintf("%s:%s:0", g.meterTypeSymbol, g.id.spectatordId)
-	g.writer.Write(line)
+	writeLineInt(g.writer, g.meterTypeSymbol, g.id.spectatordId, 0)
 }

--- a/spectator/meter/bench_hotpath_test.go
+++ b/spectator/meter/bench_hotpath_test.go
@@ -1,0 +1,52 @@
+package meter
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/Netflix/spectator-go/v2/spectator/writer"
+)
+
+// BenchmarkCounterAddCombined measures a combined meter creation and write path:
+// NewId (tag copy + toSpectatorIdFromPairs) → NewCounter → Add (writeLineInt + writer.Write).
+func BenchmarkCounterAddCombined(b *testing.B) {
+	w := &writer.NoopWriter{}
+	tags := map[string]string{
+		"nf.app":     "meshcontrol-xds",
+		"nf.cluster": "meshcontrol-xds-main",
+		"nf.asg":     "meshcontrol-xds-main-v042",
+		"nf.region":  "us-east-1",
+		"id":         "envoy.cluster.upstream_cx_active",
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c := NewCounter(NewId("spectator.meter.count", tags), w)
+		c.Add(1)
+	}
+}
+
+// BenchmarkCounterAddCombinedPostGC measures the combined path with periodic GC to validate
+// pool repopulation cost. With a single shared byteBufPool, only one buffer
+// allocation is needed per P after GC (vs two with separate pools).
+func BenchmarkCounterAddCombinedPostGC(b *testing.B) {
+	w := &writer.NoopWriter{}
+	tags := map[string]string{
+		"nf.app":     "meshcontrol-xds",
+		"nf.cluster": "meshcontrol-xds-main",
+		"nf.asg":     "meshcontrol-xds-main-v042",
+		"nf.region":  "us-east-1",
+		"id":         "envoy.cluster.upstream_cx_active",
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if i%1024 == 0 {
+			runtime.GC()
+		}
+		c := NewCounter(NewId("spectator.meter.count", tags), w)
+		c.Add(1)
+	}
+}

--- a/spectator/meter/counter.go
+++ b/spectator/meter/counter.go
@@ -1,7 +1,6 @@
 package meter
 
 import (
-	"fmt"
 	"github.com/Netflix/spectator-go/v2/spectator/writer"
 )
 
@@ -30,22 +29,19 @@ func (c *Counter) MeterId() *Id {
 
 // Increment increments the counter.
 func (c *Counter) Increment() {
-	var line = fmt.Sprintf("%s:%s:%d", c.meterTypeSymbol, c.id.spectatordId, 1)
-	c.writer.Write(line)
+	writeLineInt(c.writer, c.meterTypeSymbol, c.id.spectatordId, 1)
 }
 
 // Add adds an int64 delta to the current measurement.
 func (c *Counter) Add(delta int64) {
 	if delta > 0 {
-		var line = fmt.Sprintf("%s:%s:%d", c.meterTypeSymbol, c.id.spectatordId, delta)
-		c.writer.Write(line)
+		writeLineInt(c.writer, c.meterTypeSymbol, c.id.spectatordId, delta)
 	}
 }
 
 // AddFloat adds a float64 delta to the current measurement.
 func (c *Counter) AddFloat(delta float64) {
 	if delta > 0.0 {
-		var line = fmt.Sprintf("%s:%s:%f", c.meterTypeSymbol, c.id.spectatordId, delta)
-		c.writer.Write(line)
+		writeLineFloat(c.writer, c.meterTypeSymbol, c.id.spectatordId, delta)
 	}
 }

--- a/spectator/meter/dist_summary.go
+++ b/spectator/meter/dist_summary.go
@@ -1,7 +1,6 @@
 package meter
 
 import (
-	"fmt"
 	"github.com/Netflix/spectator-go/v2/spectator/writer"
 )
 
@@ -32,7 +31,6 @@ func (d *DistributionSummary) MeterId() *Id {
 // Record records a value to track within the distribution.
 func (d *DistributionSummary) Record(amount int64) {
 	if amount >= 0 {
-		var line = fmt.Sprintf("%s:%s:%d", d.meterTypeSymbol, d.id.spectatordId, amount)
-		d.writer.Write(line)
+		writeLineInt(d.writer, d.meterTypeSymbol, d.id.spectatordId, amount)
 	}
 }

--- a/spectator/meter/gauge.go
+++ b/spectator/meter/gauge.go
@@ -2,8 +2,9 @@ package meter
 
 import (
 	"fmt"
-	"github.com/Netflix/spectator-go/v2/spectator/writer"
 	"time"
+
+	"github.com/Netflix/spectator-go/v2/spectator/writer"
 )
 
 // Gauge represents a value that is sampled at a specific point in time. One
@@ -37,6 +38,5 @@ func (g *Gauge) MeterId() *Id {
 
 // Set records the current value.
 func (g *Gauge) Set(value float64) {
-	var line = fmt.Sprintf("%s:%s:%f", g.meterTypeSymbol, g.id.spectatordId, value)
-	g.writer.Write(line)
+	writeLineFloat(g.writer, g.meterTypeSymbol, g.id.spectatordId, value)
 }

--- a/spectator/meter/id.go
+++ b/spectator/meter/id.go
@@ -85,12 +85,10 @@ func NewId(name string, tags map[string]string) *Id {
 		myTags[k] = v
 	}
 
-	spectatorId := toSpectatorId(name, tags)
-
 	return &Id{
 		name:         name,
 		tags:         myTags,
-		spectatordId: spectatorId,
+		spectatordId: toSpectatorId(name, tags),
 	}
 }
 
@@ -143,28 +141,33 @@ func (id *Id) WithTags(tags map[string]string) *Id {
 }
 
 func toSpectatorId(name string, tags map[string]string) string {
-	var sb strings.Builder
-	writeSanitized(&sb, name)
+	bp := byteBufPool.Get().(*[]byte)
+	b := (*bp)[:0]
 
-	// Append sanitized keys and values.
+	b = appendSanitized(b, name)
+
 	for k, v := range tags {
-		sb.WriteString(",")
-		writeSanitized(&sb, k)
-		sb.WriteString("=")
-		writeSanitized(&sb, v)
+		b = append(b, ',')
+		b = appendSanitized(b, k)
+		b = append(b, '=')
+		b = appendSanitized(b, v)
 	}
 
-	return sb.String()
+	result := string(b)
+	*bp = b
+	byteBufPool.Put(bp)
+	return result
 }
 
-func writeSanitized(sb *strings.Builder, input string) {
+func appendSanitized(dst []byte, input string) []byte {
 	for _, r := range input {
 		if !isValidCharacter(r) {
-			sb.WriteRune('_')
+			dst = append(dst, '_')
 		} else {
-			sb.WriteRune(r)
+			dst = append(dst, byte(r))
 		}
 	}
+	return dst
 }
 
 func isValidCharacter(r rune) bool {

--- a/spectator/meter/line_protocol.go
+++ b/spectator/meter/line_protocol.go
@@ -1,0 +1,63 @@
+package meter
+
+import (
+	"strconv"
+	"sync"
+
+	"github.com/Netflix/spectator-go/v2/spectator/writer"
+)
+
+// byteBufPool holds reusable byte-slice buffers for building spectatord
+// protocol strings (both line-protocol values and spectator IDs), avoiding
+// fmt.Sprintf boxing overhead. Using *[]byte so we can preserve capacity
+// across calls by resetting to len=0 without clearing the backing array.
+var byteBufPool = sync.Pool{
+	New: func() interface{} {
+		b := make([]byte, 0, 256)
+		return &b
+	},
+}
+
+func appendLinePrefix(dst []byte, symbol string, spectatordId string) []byte {
+	dst = append(dst, symbol...)
+	dst = append(dst, ':')
+	dst = append(dst, spectatordId...)
+	dst = append(dst, ':')
+	return dst
+}
+
+// writeLineInt writes "symbol:spectatordId:val" to w using a pooled buffer,
+// replacing fmt.Sprintf("%s:%s:%d", ...) with zero-alloc integer formatting.
+func writeLineInt(w writer.Writer, symbol string, spectatordId string, val int64) {
+	bp := byteBufPool.Get().(*[]byte)
+	b := appendLinePrefix((*bp)[:0], symbol, spectatordId)
+	b = strconv.AppendInt(b, val, 10)
+	// Use Write to preserve buffering behavior in wrapped writers.
+	w.Write(string(b))
+	*bp = b
+	byteBufPool.Put(bp)
+}
+
+// writeLineFloat writes "symbol:spectatordId:val" to w using a pooled buffer,
+// replacing fmt.Sprintf("%s:%s:%f", ...) with zero-alloc float formatting.
+func writeLineFloat(w writer.Writer, symbol string, spectatordId string, val float64) {
+	bp := byteBufPool.Get().(*[]byte)
+	b := appendLinePrefix((*bp)[:0], symbol, spectatordId)
+	b = strconv.AppendFloat(b, val, 'f', 6, 64)
+	// Use Write to preserve buffering behavior in wrapped writers.
+	w.Write(string(b))
+	*bp = b
+	byteBufPool.Put(bp)
+}
+
+// writeLineUint writes "symbol:spectatordId:val" to w using a pooled buffer,
+// replacing fmt.Sprintf("%s:%s:%d", ...) with zero-alloc uint formatting.
+func writeLineUint(w writer.Writer, symbol string, spectatordId string, val uint64) {
+	bp := byteBufPool.Get().(*[]byte)
+	b := appendLinePrefix((*bp)[:0], symbol, spectatordId)
+	b = strconv.AppendUint(b, val, 10)
+	// Use Write to preserve buffering behavior in wrapped writers.
+	w.Write(string(b))
+	*bp = b
+	byteBufPool.Put(bp)
+}

--- a/spectator/meter/line_protocol_test.go
+++ b/spectator/meter/line_protocol_test.go
@@ -1,0 +1,81 @@
+package meter
+
+import (
+	"math"
+	"testing"
+
+	"github.com/Netflix/spectator-go/v2/spectator/writer"
+)
+
+func TestWriteLineInt(t *testing.T) {
+	tests := map[string]struct {
+		symbol   string
+		spectId  string
+		val      int64
+		expected string
+	}{
+		"zero":      {symbol: "c", spectId: "name", val: 0, expected: "c:name:0"},
+		"positive":  {symbol: "c", spectId: "name", val: 42, expected: "c:name:42"},
+		"negative":  {symbol: "c", spectId: "name", val: -1, expected: "c:name:-1"},
+		"max_int64": {symbol: "c", spectId: "name", val: math.MaxInt64, expected: "c:name:9223372036854775807"},
+		"min_int64": {symbol: "c", spectId: "name", val: math.MinInt64, expected: "c:name:-9223372036854775808"},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			w := writer.MemoryWriter{}
+			writeLineInt(&w, tt.symbol, tt.spectId, tt.val)
+			if got := w.Lines()[0]; got != tt.expected {
+				t.Errorf("Expected line to be %s, got %s", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestWriteLineFloat(t *testing.T) {
+	tests := map[string]struct {
+		symbol   string
+		spectId  string
+		val      float64
+		expected string
+	}{
+		"zero":                {symbol: "g", spectId: "name", val: 0.0, expected: "g:name:0.000000"},
+		"positive":            {symbol: "g", spectId: "name", val: 100.1, expected: "g:name:100.100000"},
+		"negative":            {symbol: "g", spectId: "name", val: -100.1, expected: "g:name:-100.100000"},
+		"tiny_rounds_to_zero": {symbol: "g", spectId: "name", val: 1e-7, expected: "g:name:0.000000"},
+		"large":               {symbol: "g", spectId: "name", val: 1e15, expected: "g:name:1000000000000000.000000"},
+		"nan":                 {symbol: "g", spectId: "name", val: math.NaN(), expected: "g:name:NaN"},
+		"positive_inf":        {symbol: "g", spectId: "name", val: math.Inf(1), expected: "g:name:+Inf"},
+		"negative_inf":        {symbol: "g", spectId: "name", val: math.Inf(-1), expected: "g:name:-Inf"},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			w := writer.MemoryWriter{}
+			writeLineFloat(&w, tt.symbol, tt.spectId, tt.val)
+			if got := w.Lines()[0]; got != tt.expected {
+				t.Errorf("Expected line to be %s, got %s", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestWriteLineUint(t *testing.T) {
+	tests := map[string]struct {
+		symbol   string
+		spectId  string
+		val      uint64
+		expected string
+	}{
+		"zero":       {symbol: "U", spectId: "name", val: 0, expected: "U:name:0"},
+		"positive":   {symbol: "U", spectId: "name", val: 42, expected: "U:name:42"},
+		"max_uint64": {symbol: "U", spectId: "name", val: math.MaxUint64, expected: "U:name:18446744073709551615"},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			w := writer.MemoryWriter{}
+			writeLineUint(&w, tt.symbol, tt.spectId, tt.val)
+			if got := w.Lines()[0]; got != tt.expected {
+				t.Errorf("Expected line to be %s, got %s", tt.expected, got)
+			}
+		})
+	}
+}

--- a/spectator/meter/max_gauge.go
+++ b/spectator/meter/max_gauge.go
@@ -1,7 +1,6 @@
 package meter
 
 import (
-	"fmt"
 	"github.com/Netflix/spectator-go/v2/spectator/writer"
 )
 
@@ -31,6 +30,5 @@ func (g *MaxGauge) MeterId() *Id {
 
 // Set records the current value.
 func (g *MaxGauge) Set(value float64) {
-	var line = fmt.Sprintf("%s:%s:%f", g.meterTypeSymbol, g.id.spectatordId, value)
-	g.writer.Write(line)
+	writeLineFloat(g.writer, g.meterTypeSymbol, g.id.spectatordId, value)
 }

--- a/spectator/meter/monotonic_counter.go
+++ b/spectator/meter/monotonic_counter.go
@@ -1,7 +1,6 @@
 package meter
 
 import (
-	"fmt"
 	"github.com/Netflix/spectator-go/v2/spectator/writer"
 )
 
@@ -35,6 +34,5 @@ func (c *MonotonicCounter) MeterId() *Id {
 
 // Set sets a value as the current measurement; spectatord calculates the delta.
 func (c *MonotonicCounter) Set(value float64) {
-	var line = fmt.Sprintf("%s:%s:%f", c.meterTypeSymbol, c.id.spectatordId, value)
-	c.writer.Write(line)
+	writeLineFloat(c.writer, c.meterTypeSymbol, c.id.spectatordId, value)
 }

--- a/spectator/meter/monotonic_counter_uint.go
+++ b/spectator/meter/monotonic_counter_uint.go
@@ -1,7 +1,6 @@
 package meter
 
 import (
-	"fmt"
 	"github.com/Netflix/spectator-go/v2/spectator/writer"
 )
 
@@ -35,6 +34,5 @@ func (c *MonotonicCounterUint) MeterId() *Id {
 
 // Set sets a value as the current measurement; spectatord calculates the delta.
 func (c *MonotonicCounterUint) Set(value uint64) {
-	var line = fmt.Sprintf("%s:%s:%d", c.meterTypeSymbol, c.id.spectatordId, value)
-	c.writer.Write(line)
+	writeLineUint(c.writer, c.meterTypeSymbol, c.id.spectatordId, value)
 }

--- a/spectator/meter/percentile_distsummary.go
+++ b/spectator/meter/percentile_distsummary.go
@@ -1,7 +1,6 @@
 package meter
 
 import (
-	"fmt"
 	"github.com/Netflix/spectator-go/v2/spectator/writer"
 )
 
@@ -25,7 +24,6 @@ func NewPercentileDistributionSummary(id *Id, writer writer.Writer) *PercentileD
 // Record records an amount to track within the distribution.
 func (p *PercentileDistributionSummary) Record(amount int64) {
 	if amount >= 0 {
-		var line = fmt.Sprintf("%s:%s:%d", p.meterTypeSymbol, p.id.spectatordId, amount)
-		p.writer.Write(line)
+		writeLineInt(p.writer, p.meterTypeSymbol, p.id.spectatordId, amount)
 	}
 }

--- a/spectator/meter/percentile_timer.go
+++ b/spectator/meter/percentile_timer.go
@@ -1,9 +1,9 @@
 package meter
 
 import (
-	"fmt"
-	"github.com/Netflix/spectator-go/v2/spectator/writer"
 	"time"
+
+	"github.com/Netflix/spectator-go/v2/spectator/writer"
 )
 
 // PercentileTimer represents timing events, while capturing the histogram
@@ -28,7 +28,6 @@ func (t *PercentileTimer) MeterId() *Id {
 // Record records the value for a single event.
 func (t *PercentileTimer) Record(amount time.Duration) {
 	if amount >= 0 {
-		var line = fmt.Sprintf("%s:%s:%f", t.meterTypeSymbol, t.id.spectatordId, amount.Seconds())
-		t.writer.Write(line)
+		writeLineFloat(t.writer, t.meterTypeSymbol, t.id.spectatordId, amount.Seconds())
 	}
 }

--- a/spectator/meter/timer.go
+++ b/spectator/meter/timer.go
@@ -1,9 +1,9 @@
 package meter
 
 import (
-	"fmt"
-	"github.com/Netflix/spectator-go/v2/spectator/writer"
 	"time"
+
+	"github.com/Netflix/spectator-go/v2/spectator/writer"
 )
 
 // Timer is used to measure how long (in seconds) some event is taking. This
@@ -27,7 +27,6 @@ func (t *Timer) MeterId() *Id {
 // Record records the duration this specific event took.
 func (t *Timer) Record(amount time.Duration) {
 	if amount >= 0 {
-		var line = fmt.Sprintf("%s:%s:%f", t.meterTypeSymbol, t.id.spectatordId, amount.Seconds())
-		t.writer.Write(line)
+		writeLineFloat(t.writer, t.meterTypeSymbol, t.id.spectatordId, amount.Seconds())
 	}
 }


### PR DESCRIPTION
## Summary
- route meter writes through shared line-protocol helpers instead of per-call `fmt.Sprintf`
- switch spectatord ID construction to a pooled byte builder while keeping `Id` map-backed in this first step
- add hot-path benchmarks for `NewId -> NewCounter -> Add`

## Benchmark results
Baseline: `main`

```text
name                           old time/op    new time/op    delta
CounterAddCombined-12           1020.0ns       500.1ns      -50.97%
CounterAddCombinedPostGC-12     1107.5ns       585.8ns      -47.11%
ToSpectatorIdBuilder-12          731.6ns       338.9ns      -53.69%
geomean                          938.5ns       463.0ns      -50.66%

name                           old B/op       new B/op      delta
CounterAddCombined-12            1128.0         768.0       -31.91%
CounterAddCombinedPostGC-12      1130.0         769.0       -31.95%
ToSpectatorIdBuilder-12           504.0         176.0       -65.08%
geomean                           862.9         470.2       -45.51%

name                           old allocs/op  new allocs/op delta
CounterAddCombined-12             12.000         5.000      -58.33%
CounterAddCombinedPostGC-12       12.000         5.000      -58.33%
ToSpectatorIdBuilder-12            6.000         1.000      -83.33%
geomean                            9.524         2.924      -69.30%
```

## Test plan
- [x] `go test ./spectator/meter`
- [x] `go test ./spectator/meter -run '^$' -bench 'BenchmarkCounterAddCombined$|BenchmarkCounterAddCombinedPostGC$|BenchmarkToSpectatorIdBuilder$' -benchmem -count=10`

Made with [Cursor](https://cursor.com)