### PR TITLE
Optimize meter Id tag storage

### DIFF
--- a/spectator/meter/id.go
+++ b/spectator/meter/id.go
@@ -7,10 +7,64 @@ import (
 	"sync"
 )
 
+type tagPair struct {
+	key   string
+	value string
+}
+
+type tagPairs []tagPair
+
+func newTagPairs(tags map[string]string) tagPairs {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	flat := make(tagPairs, 0, len(tags))
+	for k, v := range tags {
+		flat = append(flat, tagPair{key: k, value: v})
+	}
+	return flat
+}
+
+func (tags tagPairs) clone(extraPairs int) tagPairs {
+	cloned := make(tagPairs, len(tags), len(tags)+extraPairs)
+	copy(cloned, tags)
+	return cloned
+}
+
+func (tags tagPairs) upsert(key string, value string) tagPairs {
+	for i := range tags {
+		if tags[i].key == key {
+			tags[i].value = value
+			return tags
+		}
+	}
+	return append(tags, tagPair{key: key, value: value})
+}
+
+func (tags tagPairs) sorted() []tagPair {
+	pairs := make([]tagPair, len(tags))
+	copy(pairs, tags)
+	sort.Slice(pairs, func(i int, j int) bool {
+		return pairs[i].key < pairs[j].key
+	})
+	return pairs
+}
+
+func (tags tagPairs) toMap() map[string]string {
+	m := make(map[string]string, len(tags))
+	for i := range tags {
+		m[tags[i].key] = tags[i].value
+	}
+	return m
+}
+
 // Id represents a meter's identifying information and dimensions (tags).
 type Id struct {
 	name string
-	tags map[string]string
+	// tags stores key/value pairs in a slice to avoid the allocation overhead
+	// of a map while keeping the representation explicit.
+	tags tagPairs
 	// keyOnce protects access to key, allowing it to be computed on demand
 	// without racing other readers.
 	keyOnce sync.Once
@@ -19,7 +73,7 @@ type Id struct {
 	spectatordId string
 }
 
-var builderPool = &sync.Pool{
+var builderPool = sync.Pool{
 	New: func() interface{} {
 		return &strings.Builder{}
 	},
@@ -46,19 +100,18 @@ func (id *Id) MapKey() string {
 			if err != nil {
 				return errKey
 			}
-			keys := make([]string, 0, len(id.tags))
-			for k := range id.tags {
-				keys = append(keys, k)
-			}
-			sort.Strings(keys)
 
-			for _, k := range keys {
-				v := id.tags[k]
+			pairs := id.tags.sorted()
+			if len(pairs) == 0 {
+				return buf.String()
+			}
+
+			for i := range pairs {
 				_, err = buf.WriteRune('|')
 				if err != nil {
 					return errKey
 				}
-				_, err = buf.WriteString(k)
+				_, err = buf.WriteString(pairs[i].key)
 				if err != nil {
 					return errKey
 				}
@@ -66,7 +119,7 @@ func (id *Id) MapKey() string {
 				if err != nil {
 					return errKey
 				}
-				_, err = buf.WriteString(v)
+				_, err = buf.WriteString(pairs[i].value)
 				if err != nil {
 					return errKey
 				}
@@ -80,33 +133,34 @@ func (id *Id) MapKey() string {
 // NewId generates a new *Id from the metric name, and the tags you want to
 // include on your metric.
 func NewId(name string, tags map[string]string) *Id {
-	myTags := make(map[string]string)
-	for k, v := range tags {
-		myTags[k] = v
-	}
+	pairs := newTagPairs(tags)
 
 	return &Id{
 		name:         name,
-		tags:         myTags,
-		spectatordId: toSpectatorId(name, tags),
+		tags:         pairs,
+		spectatordId: toSpectatorIdFromPairs(name, pairs),
+	}
+}
+
+// newIdFromPairs creates an *Id directly from a pre-built tag slice,
+// avoiding an intermediate map allocation. Used by WithTag and WithTags.
+func newIdFromPairs(name string, tags tagPairs) *Id {
+	return &Id{
+		name:         name,
+		tags:         tags,
+		spectatordId: toSpectatorIdFromPairs(name, tags),
 	}
 }
 
 // WithTag creates a deep copy of the *Id, adding the requested tag to the
 // internal collection.
 func (id *Id) WithTag(key string, value string) *Id {
-	newTags := make(map[string]string)
-
-	for k, v := range id.tags {
-		newTags[k] = v
-	}
-	newTags[key] = value
-
-	return NewId(id.name, newTags)
+	newTags := id.tags.clone(1).upsert(key, value)
+	return newIdFromPairs(id.name, newTags)
 }
 
 func (id *Id) String() string {
-	return fmt.Sprintf("Id{name=%s,tags=%v}", id.name, id.tags)
+	return fmt.Sprintf("Id{name=%s,tags=%v}", id.name, id.Tags())
 }
 
 // Name exposes the internal metric name field.
@@ -114,10 +168,10 @@ func (id *Id) Name() string {
 	return id.name
 }
 
-// Tags directly exposes the internal tags map. This is not a copy of the map,
-// so any modifications to it will be observed by the *Id.
+// Tags returns a new map containing the identifier's tags. Each call allocates
+// a fresh map; mutating the returned map does not affect the *Id.
 func (id *Id) Tags() map[string]string {
-	return id.tags
+	return id.tags.toMap()
 }
 
 // WithTags takes a map of tags, and returns a deep copy of *Id with the new
@@ -128,29 +182,27 @@ func (id *Id) WithTags(tags map[string]string) *Id {
 		return id
 	}
 
-	newTags := make(map[string]string)
-
-	for k, v := range id.tags {
-		newTags[k] = v
-	}
-
+	newTags := id.tags.clone(len(tags))
 	for k, v := range tags {
-		newTags[k] = v
+		newTags = newTags.upsert(k, v)
 	}
-	return NewId(id.name, newTags)
+	return newIdFromPairs(id.name, newTags)
 }
 
-func toSpectatorId(name string, tags map[string]string) string {
+// toSpectatorIdFromPairs builds the spectatord line-protocol name from tag
+// pairs. Reuses a pooled buffer to avoid builder
+// growth allocations; the only allocation is the returned string.
+func toSpectatorIdFromPairs(name string, tags tagPairs) string {
 	bp := byteBufPool.Get().(*[]byte)
 	b := (*bp)[:0]
 
 	b = appendSanitized(b, name)
 
-	for k, v := range tags {
+	for i := range tags {
 		b = append(b, ',')
-		b = appendSanitized(b, k)
+		b = appendSanitized(b, tags[i].key)
 		b = append(b, '=')
-		b = appendSanitized(b, v)
+		b = appendSanitized(b, tags[i].value)
 	}
 
 	result := string(b)
@@ -159,12 +211,15 @@ func toSpectatorId(name string, tags map[string]string) string {
 	return result
 }
 
+// appendSanitized appends the sanitized form of input to dst and returns the
+// extended slice. Every rune that passes isValidCharacter (all ASCII single-byte)
+// is appended directly; invalid runes become '_'.
 func appendSanitized(dst []byte, input string) []byte {
 	for _, r := range input {
-		if !isValidCharacter(r) {
-			dst = append(dst, '_')
-		} else {
+		if isValidCharacter(r) {
 			dst = append(dst, byte(r))
+		} else {
+			dst = append(dst, '_')
 		}
 	}
 	return dst

--- a/spectator/meter/id_test.go
+++ b/spectator/meter/id_test.go
@@ -100,50 +100,214 @@ func TestId_WithTags(t *testing.T) {
 	}
 }
 
-func TestToSpectatorId(t *testing.T) {
-	name := "test"
-	tags := map[string]string{
-		"tag1": "value1",
-		"tag2": "value2",
+func TestTagPairs_clone(t *testing.T) {
+	tests := map[string]struct {
+		input      tagPairs
+		extraPairs int
+		wantLen    int
+		wantCap    int
+	}{
+		"nil":            {input: nil, extraPairs: 0, wantLen: 0, wantCap: 0},
+		"empty":          {input: tagPairs{}, extraPairs: 0, wantLen: 0, wantCap: 0},
+		"extra capacity": {input: tagPairs{{key: "a", value: "1"}}, extraPairs: 3, wantLen: 1, wantCap: 4},
+		"zero extra":     {input: tagPairs{{key: "a", value: "1"}}, extraPairs: 0, wantLen: 1, wantCap: 1},
+		"multiple":       {input: tagPairs{{key: "a", value: "1"}, {key: "b", value: "2"}}, extraPairs: 1, wantLen: 2, wantCap: 3},
 	}
-
-	// The order of the tags is not guaranteed
-	expected1 := "test,tag1=value1,tag2=value2"
-	expected2 := "test,tag2=value2,tag1=value1"
-	result := toSpectatorId(name, tags)
-
-	if result != expected1 && result != expected2 {
-		t.Errorf("Expected '%s' or '%s', got '%s'", expected1, expected2, result)
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			cloned := tt.input.clone(tt.extraPairs)
+			if len(cloned) != tt.wantLen {
+				t.Errorf("len = %d, want %d", len(cloned), tt.wantLen)
+			}
+			if cap(cloned) != tt.wantCap {
+				t.Errorf("cap = %d, want %d", cap(cloned), tt.wantCap)
+			}
+		})
 	}
 }
 
-func TestToSpectatorId_EmptyTags(t *testing.T) {
-	name := "test"
-	tags := map[string]string{}
+func TestTagPairs_clone_independent(t *testing.T) {
+	orig := tagPairs{{key: "a", value: "1"}}
+	cloned := orig.clone(0)
+	cloned[0].value = "changed"
+	if orig[0].value != "1" {
+		t.Errorf("clone mutated original: got %q, want %q", orig[0].value, "1")
+	}
+}
 
-	expected := "test"
-	result := toSpectatorId(name, tags)
+func TestTagPairs_upsert(t *testing.T) {
+	tests := map[string]struct {
+		input    tagPairs
+		key      string
+		value    string
+		wantLen  int
+		wantTags map[string]string
+	}{
+		"nil append": {
+			input: nil, key: "a", value: "1",
+			wantLen: 1, wantTags: map[string]string{"a": "1"},
+		},
+		"empty append": {
+			input: tagPairs{}, key: "a", value: "1",
+			wantLen: 1, wantTags: map[string]string{"a": "1"},
+		},
+		"append new": {
+			input: tagPairs{{key: "a", value: "1"}}, key: "b", value: "2",
+			wantLen: 2, wantTags: map[string]string{"a": "1", "b": "2"},
+		},
+		"update existing": {
+			input: tagPairs{{key: "a", value: "1"}, {key: "b", value: "2"}}, key: "a", value: "replaced",
+			wantLen: 2, wantTags: map[string]string{"a": "replaced", "b": "2"},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := tt.input.upsert(tt.key, tt.value)
+			if len(result) != tt.wantLen {
+				t.Errorf("len = %d, want %d", len(result), tt.wantLen)
+			}
+			if got := result.toMap(); !reflect.DeepEqual(got, tt.wantTags) {
+				t.Errorf("toMap = %v, want %v", got, tt.wantTags)
+			}
+		})
+	}
+}
 
+func TestTagPairs_sorted(t *testing.T) {
+	tests := map[string]struct {
+		input tagPairs
+		want  []tagPair
+	}{
+		"nil":      {input: nil, want: []tagPair{}},
+		"empty":    {input: tagPairs{}, want: []tagPair{}},
+		"single":   {input: tagPairs{{key: "a", value: "1"}}, want: []tagPair{{key: "a", value: "1"}}},
+		"reversed": {input: tagPairs{{key: "c", value: "3"}, {key: "a", value: "1"}, {key: "b", value: "2"}}, want: []tagPair{{key: "a", value: "1"}, {key: "b", value: "2"}, {key: "c", value: "3"}}},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := tt.input.sorted()
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("sorted = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTagPairs_sorted_does_not_mutate(t *testing.T) {
+	orig := tagPairs{{key: "c", value: "3"}, {key: "a", value: "1"}}
+	_ = orig.sorted()
+	if orig[0].key != "c" {
+		t.Errorf("sorted mutated original: first key = %q, want %q", orig[0].key, "c")
+	}
+}
+
+func TestTagPairs_toMap(t *testing.T) {
+	tests := map[string]struct {
+		input tagPairs
+		want  map[string]string
+	}{
+		"nil":      {input: nil, want: map[string]string{}},
+		"empty":    {input: tagPairs{}, want: map[string]string{}},
+		"single":   {input: tagPairs{{key: "a", value: "1"}}, want: map[string]string{"a": "1"}},
+		"multiple": {input: tagPairs{{key: "a", value: "1"}, {key: "b", value: "2"}}, want: map[string]string{"a": "1", "b": "2"}},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := tt.input.toMap()
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("toMap = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestId_WithTag(t *testing.T) {
+	tests := map[string]struct {
+		baseTags     map[string]string
+		key          string
+		value        string
+		expectedTags map[string]string
+	}{
+		"add new key": {
+			baseTags:     map[string]string{"a": "1"},
+			key:          "b",
+			value:        "2",
+			expectedTags: map[string]string{"a": "1", "b": "2"},
+		},
+		"replace existing key": {
+			baseTags:     map[string]string{"a": "1", "b": "2"},
+			key:          "a",
+			value:        "replaced",
+			expectedTags: map[string]string{"a": "replaced", "b": "2"},
+		},
+		"no existing tags": {
+			baseTags:     nil,
+			key:          "a",
+			value:        "1",
+			expectedTags: map[string]string{"a": "1"},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			id := NewId("foo", tt.baseTags)
+			id2 := id.WithTag(tt.key, tt.value)
+
+			if !reflect.DeepEqual(tt.expectedTags, id2.Tags()) {
+				t.Errorf("Expected %v, got %v", tt.expectedTags, id2.Tags())
+			}
+		})
+	}
+}
+
+func TestId_WithTag_DoesNotMutateOriginal(t *testing.T) {
+	id := NewId("foo", map[string]string{"a": "1"})
+	_ = id.WithTag("b", "2")
+
+	expected := map[string]string{"a": "1"}
+	if !reflect.DeepEqual(expected, id.Tags()) {
+		t.Errorf("Original mutated: expected %v, got %v", expected, id.Tags())
+	}
+}
+
+func TestToSpectatorIdFromPairs_InvalidTags(t *testing.T) {
+	name := "test`!@#$%^&*()-=~_+[]{}\\|;:'\",<.>/?foo"
+	tags := tagPairs{
+		{key: "tag1,:=", value: "value1,:="},
+		{key: "tag2,;=", value: "value2,;="},
+	}
+	result := toSpectatorIdFromPairs(name, tags)
+
+	// Tags appear in insertion order, so order is deterministic.
+	expected := "test______^____-_~______________.___foo,tag1___=value1___,tag2___=value2___"
 	if result != expected {
 		t.Errorf("Expected '%s', got '%s'", expected, result)
 	}
 }
 
-func TestToSpectatorId_InvalidTags(t *testing.T) {
-	name := "test`!@#$%^&*()-=~_+[]{}\\|;:'\",<.>/?foo"
-	tags := map[string]string{
-		"tag1,:=": "value1,:=",
-		"tag2,;=": "value2,;=",
+func TestToSpectatorIdFromPairs(t *testing.T) {
+	tests := map[string]struct {
+		metric   string
+		tags     tagPairs
+		expected string
+	}{
+		"no tags":        {metric: "test", tags: nil, expected: "test"},
+		"empty tags":     {metric: "test", tags: tagPairs{}, expected: "test"},
+		"one tag":        {metric: "test", tags: tagPairs{{key: "k1", value: "v1"}}, expected: "test,k1=v1"},
+		"two tags":       {metric: "test", tags: tagPairs{{key: "k1", value: "v1"}, {key: "k2", value: "v2"}}, expected: "test,k1=v1,k2=v2"},
+		"sanitized name": {metric: "test!@#", tags: nil, expected: "test___"},
+		"sanitized tags": {metric: "test", tags: tagPairs{{key: "k!ey", value: "v@lue"}}, expected: "test,k_ey=v_lue"},
 	}
-
-	expected1 := "test______^____-_~______________.___foo,tag1___=value1___,tag2___=value2___"
-	expected2 := "test______^____-_~______________.___foo,tag2___=value2___,tag1___=value1___"
-	result := toSpectatorId(name, tags)
-
-	if result != expected1 && result != expected2 {
-		t.Errorf("Expected '%s' or '%s', got '%s'", expected1, expected2, result)
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := toSpectatorIdFromPairs(tt.metric, tt.tags)
+			if result != tt.expected {
+				t.Errorf("Expected '%s', got '%s'", tt.expected, result)
+			}
+		})
 	}
 }
+
+var benchSinkString string
 
 var benchName = "my.metric.with_a_fairly_long_name.and.some.invalid.chars!@#"
 var benchTags = map[string]string{
@@ -182,13 +346,18 @@ func BenchmarkToSpectatorId(b *testing.B) {
 
 	b.ReportAllocs()
 	for n := 0; n < b.N; n++ {
-		_ = originalToSpectatorId(benchName, benchTags)
+		benchSinkString = originalToSpectatorId(benchName, benchTags)
 	}
 }
 
-func BenchmarkToSpectatorIdBuilder(b *testing.B) {
+func BenchmarkToSpectatorIdFromPairs(b *testing.B) {
+	tags := make(tagPairs, 0, len(benchTags))
+	for k, v := range benchTags {
+		tags = append(tags, tagPair{key: k, value: v})
+	}
 	b.ReportAllocs()
+	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		_ = toSpectatorId(benchName, benchTags)
+		benchSinkString = toSpectatorIdFromPairs(benchName, tags)
 	}
 }


### PR DESCRIPTION
## Summary
- store `Id` tags as ordered pairs instead of copying maps through each clone path
- keep the line-protocol and builder changes from the base PR and make `WithTag`/`WithTags` cheaper on top
- add focused `Id` tests for clone, upsert, sorted, and `toMap` behavior

## Benchmark results
Baseline: #124

```text
name                           old time/op    new time/op    delta
CounterAddCombined-12            492.8ns       398.2ns      -19.21%
CounterAddCombinedPostGC-12      586.8ns       487.9ns      -16.84%
geomean                          537.7ns       440.8ns      -18.03%

name                           old B/op       new B/op      delta
CounterAddCombined-12             768.0         608.0       -20.83%
CounterAddCombinedPostGC-12       769.0         609.0       -20.81%
geomean                           768.5         608.5       -20.82%

name                           old allocs/op  new allocs/op delta
CounterAddCombined-12              5.000         4.000      -20.00%
CounterAddCombinedPostGC-12        5.000         4.000      -20.00%
geomean                             5.000         4.000      -20.00%
```

## Test plan
- [x] `go test ./spectator/meter`
- [x] `go test ./spectator/meter -run '^$' -bench 'BenchmarkCounterAddCombined$|BenchmarkCounterAddCombinedPostGC$' -benchmem -count=10`

Made with [Cursor](https://cursor.com)