### PR TITLE
Thread byte writes through buffered writers

### DIFF
--- a/spectator/meter/bench_writebytes_test.go
+++ b/spectator/meter/bench_writebytes_test.go
@@ -1,0 +1,80 @@
+package meter
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/Netflix/spectator-go/v2/spectator/writer"
+)
+
+var (
+	benchStringSink string
+	benchBytesSink  []byte
+)
+
+type stringOnlyWriter struct{}
+
+func (w *stringOnlyWriter) Write(line string)      { benchStringSink = line }
+func (w *stringOnlyWriter) WriteBytes(line []byte) { benchBytesSink = line }
+func (w *stringOnlyWriter) WriteString(line string) {
+	benchStringSink = line
+}
+func (w *stringOnlyWriter) Close() error { return nil }
+
+type socketLikeWriter struct{}
+
+func (w *socketLikeWriter) Write(line string) {
+	benchBytesSink = []byte(line)
+}
+func (w *socketLikeWriter) WriteBytes(line []byte) { benchBytesSink = line }
+func (w *socketLikeWriter) WriteString(line string) {
+	benchBytesSink = []byte(line)
+}
+func (w *socketLikeWriter) Close() error { return nil }
+
+func writeLineIntViaWrite(w writer.Writer, symbol string, spectatordId string, val int64) {
+	bp := byteBufPool.Get().(*[]byte)
+	b := appendLinePrefix((*bp)[:0], symbol, spectatordId)
+	b = strconv.AppendInt(b, val, 10)
+	w.Write(string(b))
+	*bp = b
+	byteBufPool.Put(bp)
+}
+
+func benchmarkWriteLineIntCurrent(b *testing.B, w writer.Writer) {
+	const symbol = "c"
+	const spectatordId = "spectator.meter.count,nf.app=meshcontrol-xds,nf.cluster=meshcontrol-xds-main,nf.asg=meshcontrol-xds-main-v042,nf.region=us-east-1,id=envoy.cluster.upstream_cx_active"
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		writeLineIntViaWrite(w, symbol, spectatordId, 1)
+	}
+}
+
+func benchmarkWriteLineIntBytes(b *testing.B, w writer.Writer) {
+	const symbol = "c"
+	const spectatordId = "spectator.meter.count,nf.app=meshcontrol-xds,nf.cluster=meshcontrol-xds-main,nf.asg=meshcontrol-xds-main-v042,nf.region=us-east-1,id=envoy.cluster.upstream_cx_active"
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		writeLineInt(w, symbol, spectatordId, 1)
+	}
+}
+
+func BenchmarkWriteLineIntCurrentStringOnlyWriter(b *testing.B) {
+	benchmarkWriteLineIntCurrent(b, &stringOnlyWriter{})
+}
+
+func BenchmarkWriteLineIntBytesStringOnlyWriter(b *testing.B) {
+	benchmarkWriteLineIntBytes(b, &stringOnlyWriter{})
+}
+
+func BenchmarkWriteLineIntCurrentSocketLikeWriter(b *testing.B) {
+	benchmarkWriteLineIntCurrent(b, &socketLikeWriter{})
+}
+
+func BenchmarkWriteLineIntBytesSocketLikeWriter(b *testing.B) {
+	benchmarkWriteLineIntBytes(b, &socketLikeWriter{})
+}

--- a/spectator/meter/line_protocol.go
+++ b/spectator/meter/line_protocol.go
@@ -32,8 +32,7 @@ func writeLineInt(w writer.Writer, symbol string, spectatordId string, val int64
 	bp := byteBufPool.Get().(*[]byte)
 	b := appendLinePrefix((*bp)[:0], symbol, spectatordId)
 	b = strconv.AppendInt(b, val, 10)
-	// Use Write to preserve buffering behavior in wrapped writers.
-	w.Write(string(b))
+	w.WriteBytes(b)
 	*bp = b
 	byteBufPool.Put(bp)
 }
@@ -44,8 +43,7 @@ func writeLineFloat(w writer.Writer, symbol string, spectatordId string, val flo
 	bp := byteBufPool.Get().(*[]byte)
 	b := appendLinePrefix((*bp)[:0], symbol, spectatordId)
 	b = strconv.AppendFloat(b, val, 'f', 6, 64)
-	// Use Write to preserve buffering behavior in wrapped writers.
-	w.Write(string(b))
+	w.WriteBytes(b)
 	*bp = b
 	byteBufPool.Put(bp)
 }
@@ -56,8 +54,7 @@ func writeLineUint(w writer.Writer, symbol string, spectatordId string, val uint
 	bp := byteBufPool.Get().(*[]byte)
 	b := appendLinePrefix((*bp)[:0], symbol, spectatordId)
 	b = strconv.AppendUint(b, val, 10)
-	// Use Write to preserve buffering behavior in wrapped writers.
-	w.Write(string(b))
+	w.WriteBytes(b)
 	*bp = b
 	byteBufPool.Put(bp)
 }

--- a/spectator/writer/line_buffer.go
+++ b/spectator/writer/line_buffer.go
@@ -1,9 +1,9 @@
 package writer
 
 import (
+	"bytes"
 	"github.com/Netflix/spectator-go/v2/spectator/logger"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 )
@@ -13,7 +13,7 @@ type LineBuffer struct {
 	logger logger.Logger
 
 	bufferSize    int
-	buffer        strings.Builder
+	buffer        bytes.Buffer
 	lineCount     int
 	flushInterval time.Duration
 	lastFlush     time.Time
@@ -42,19 +42,13 @@ func NewLineBuffer(writer Writer, logger logger.Logger, bufferSize int, flushInt
 func (lb *LineBuffer) Write(line string) {
 	lb.mu.Lock()
 	defer lb.mu.Unlock()
+	lb.writeStringLocked(line)
+}
 
-	if lb.buffer.Len() > 0 {
-		// buffer has data, so add the separator to indicate the end of the previous line
-		lb.buffer.WriteString(separator)
-	}
-
-	lb.buffer.WriteString(line)
-	lb.lineCount++
-
-	if lb.buffer.Len() >= lb.bufferSize {
-		lb.writer.WriteString("c:spectator-go.lineBuffer.overflows:1")
-		lb.flush()
-	}
+func (lb *LineBuffer) WriteBytes(line []byte) {
+	lb.mu.Lock()
+	defer lb.mu.Unlock()
+	lb.writeBytesLocked(line)
 }
 
 func (lb *LineBuffer) startFlushTimer() {
@@ -79,11 +73,41 @@ func (lb *LineBuffer) flush() {
 	}
 
 	lb.logger.Debugf("Flushing buffer with %d lines (%d bytes)", lb.lineCount, lb.buffer.Len())
-	lb.writer.WriteString(lb.buffer.String())
+	lb.writer.WriteBytes(lb.buffer.Bytes())
 	lb.writer.WriteString("c:spectator-go.lineBuffer.bytesWritten:" + strconv.Itoa(lb.buffer.Len()))
 	lb.buffer.Reset()
 	lb.lineCount = 0
 	lb.lastFlush = time.Now()
+}
+
+func (lb *LineBuffer) writeBytesLocked(line []byte) {
+	if lb.buffer.Len() > 0 {
+		// buffer has data, so add the separator to indicate the end of the previous line
+		lb.buffer.WriteString(separator)
+	}
+
+	lb.buffer.Write(line)
+	lb.lineCount++
+
+	if lb.buffer.Len() >= lb.bufferSize {
+		lb.writer.WriteString("c:spectator-go.lineBuffer.overflows:1")
+		lb.flush()
+	}
+}
+
+func (lb *LineBuffer) writeStringLocked(line string) {
+	if lb.buffer.Len() > 0 {
+		// buffer has data, so add the separator to indicate the end of the previous line
+		lb.buffer.WriteString(separator)
+	}
+
+	lb.buffer.WriteString(line)
+	lb.lineCount++
+
+	if lb.buffer.Len() >= lb.bufferSize {
+		lb.writer.WriteString("c:spectator-go.lineBuffer.overflows:1")
+		lb.flush()
+	}
 }
 
 func (lb *LineBuffer) Close() {

--- a/spectator/writer/line_buffer_bench_test.go
+++ b/spectator/writer/line_buffer_bench_test.go
@@ -1,0 +1,38 @@
+package writer
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Netflix/spectator-go/v2/spectator/logger"
+)
+
+func benchmarkLineBufferWriteString(b *testing.B, line string) {
+	buf := NewLineBuffer(&NoopWriter{}, logger.NewDefaultLogger(), 1<<30, time.Hour)
+	defer buf.Close()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		buf.Write(line)
+	}
+}
+
+func benchmarkLineBufferWriteBytes(b *testing.B, line []byte) {
+	buf := NewLineBuffer(&NoopWriter{}, logger.NewDefaultLogger(), 1<<30, time.Hour)
+	defer buf.Close()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		buf.WriteBytes(line)
+	}
+}
+
+func BenchmarkLineBufferWriteString(b *testing.B) {
+	benchmarkLineBufferWriteString(b, "spectator.meter.count,nf.app=meshcontrol-xds:1")
+}
+
+func BenchmarkLineBufferWriteBytes(b *testing.B) {
+	benchmarkLineBufferWriteBytes(b, []byte("spectator.meter.count,nf.app=meshcontrol-xds:1"))
+}

--- a/spectator/writer/lowlatency_buffer.go
+++ b/spectator/writer/lowlatency_buffer.go
@@ -34,10 +34,11 @@ type bufferShard struct {
 	mu            sync.Mutex
 }
 
-// getChunkIndexForLine returns the chunkIndex that should be used for storing the line, or -1, if there is
-// an overflow and the line cannot be stored in the bufferShard.
-func (b *bufferShard) getChunkIndexForLine(line []byte) int {
-	totalWriteLength := len(line)
+// getChunkIndexForLength returns the chunkIndex that should be used for storing
+// a line of the given length, or -1 if there is an overflow and the line
+// cannot be stored in the bufferShard.
+func (b *bufferShard) getChunkIndexForLength(lineLen int) int {
+	totalWriteLength := lineLen
 
 	// All chunks are full for the shard, drop the data
 	if b.chunkIndex >= len(b.data) {
@@ -47,7 +48,7 @@ func (b *bufferShard) getChunkIndexForLine(line []byte) int {
 	}
 
 	// This should not happen, drop the data. The maximum length of a well-formed protocol line is 3.8KB.
-	if len(line) > chunkSize {
+	if lineLen > chunkSize {
 		b.overflows++
 		b.overflowBytes += int64(totalWriteLength)
 		return -1
@@ -158,21 +159,51 @@ func (llb *LowLatencyBuffer) Write(line string) {
 	// Add the line to the appropriate chunk in the buffer shard, or drop, if it overflows
 	buffer.mu.Lock()
 	defer buffer.mu.Unlock()
-	lineBytes := []byte(line)
 
 	// Check if current chunk can fit the new data
-	idx := buffer.getChunkIndexForLine(lineBytes)
+	idx := buffer.getChunkIndexForLength(len(line))
 	if idx == -1 {
-		// overflows (drops) are counted in getChunkIndexForLine, for metric reporting
+		// overflows (drops) are counted in getChunkIndexForLength, for metric reporting
 		return
 	}
 
 	// We can write to the selected chunk
 	if len(buffer.data[buffer.chunkIndex]) > 0 {
 		// buffer has data, so add the separator, to indicate the end of the previous line
-		buffer.data[buffer.chunkIndex] = append(buffer.data[buffer.chunkIndex], []byte(separator)...)
+		buffer.data[buffer.chunkIndex] = append(buffer.data[buffer.chunkIndex], separator...)
 	}
-	buffer.data[buffer.chunkIndex] = append(buffer.data[buffer.chunkIndex], lineBytes...)
+	buffer.data[buffer.chunkIndex] = append(buffer.data[buffer.chunkIndex], line...)
+}
+
+func (llb *LowLatencyBuffer) WriteBytes(line []byte) {
+	// Pick a shard index across all shards in the active buffer, with a round-robin distribution
+	shardIndex := int(atomic.AddUint64(&llb.counter, 1)) % len(llb.frontBuffers)
+
+	// Acquire read lock, to check which buffers are active
+	var buffer *bufferShard
+	if llb.useFrontBuffers.Load() {
+		buffer = llb.frontBuffers[shardIndex]
+	} else {
+		buffer = llb.backBuffers[shardIndex]
+	}
+
+	// Add the line to the appropriate chunk in the buffer shard, or drop, if it overflows
+	buffer.mu.Lock()
+	defer buffer.mu.Unlock()
+
+	// Check if current chunk can fit the new data
+	idx := buffer.getChunkIndexForLength(len(line))
+	if idx == -1 {
+		// overflows (drops) are counted in getChunkIndexForLength, for metric reporting
+		return
+	}
+
+	// We can write to the selected chunk
+	if len(buffer.data[buffer.chunkIndex]) > 0 {
+		// buffer has data, so add the separator, to indicate the end of the previous line
+		buffer.data[buffer.chunkIndex] = append(buffer.data[buffer.chunkIndex], separator...)
+	}
+	buffer.data[buffer.chunkIndex] = append(buffer.data[buffer.chunkIndex], line...)
 }
 
 // flushLoop runs in a separate goroutine and handles buffer swapping and flushing

--- a/spectator/writer/udp_writer.go
+++ b/spectator/writer/udp_writer.go
@@ -7,14 +7,39 @@ import (
 )
 
 type UdpWriter struct {
-	conn             *net.UDPConn
-	logger           logger.Logger
+	raw              *rawUDPWriter
 	lineBuffer       *LineBuffer
 	lowLatencyBuffer *LowLatencyBuffer
 }
 
-type udpBufferWriter struct {
-	*UdpWriter
+type rawUDPWriter struct {
+	conn   *net.UDPConn
+	logger logger.Logger
+}
+
+func (u *rawUDPWriter) Write(line string) {
+	u.WriteString(line)
+}
+
+func (u *rawUDPWriter) WriteBytes(line []byte) {
+	_, err := u.conn.Write(line)
+	if err != nil {
+		u.logger.Errorf("Error writing to UDP: %s", err)
+	}
+}
+
+func (u *rawUDPWriter) WriteString(line string) {
+	_, err := u.conn.Write([]byte(line))
+	if err != nil {
+		u.logger.Errorf("Error writing to UDP: %s", err)
+	}
+}
+
+func (u *rawUDPWriter) Close() error {
+	if u.conn != nil {
+		return u.conn.Close()
+	}
+	return nil
 }
 
 func NewUdpWriter(address string, logger logger.Logger) (*UdpWriter, error) {
@@ -32,17 +57,24 @@ func NewUdpWriterWithBuffer(address string, logger logger.Logger, bufferSize int
 		return nil, err
 	}
 
-	baseWriter := &UdpWriter{
+	raw := &rawUDPWriter{
 		conn:   conn,
 		logger: logger,
+	}
+	baseWriter := &UdpWriter{
+		raw: raw,
 	}
 
 	var lineBuffer *LineBuffer
 	var lowLatencyBuffer *LowLatencyBuffer
 	if bufferSize > 0 && bufferSize <= 65536 {
-		lineBuffer = NewLineBuffer(&udpBufferWriter{baseWriter}, logger, bufferSize, flushInterval)
+		// Buffers flush through the raw socket writer, not UdpWriter, to avoid
+		// re-entering buffering logic on WriteBytes/WriteString.
+		lineBuffer = NewLineBuffer(raw, logger, bufferSize, flushInterval)
 	} else if bufferSize > 0 {
-		lowLatencyBuffer = NewLowLatencyBuffer(&udpBufferWriter{baseWriter}, logger, bufferSize, flushInterval)
+		// Buffers flush through the raw socket writer, not UdpWriter, to avoid
+		// re-entering buffering logic on WriteBytes/WriteString.
+		lowLatencyBuffer = NewLowLatencyBuffer(raw, logger, bufferSize, flushInterval)
 	}
 	baseWriter.lineBuffer = lineBuffer
 	baseWriter.lowLatencyBuffer = lowLatencyBuffer
@@ -51,7 +83,7 @@ func NewUdpWriterWithBuffer(address string, logger logger.Logger, bufferSize int
 }
 
 func (u *UdpWriter) Write(line string) {
-	u.logger.Debugf("Sending line: %s", line)
+	u.raw.logger.Debugf("Sending line: %s", line)
 
 	if u.lineBuffer != nil {
 		u.lineBuffer.Write(line)
@@ -63,21 +95,25 @@ func (u *UdpWriter) Write(line string) {
 		return
 	}
 
-	u.WriteString(line)
+	u.raw.WriteString(line)
 }
 
 func (u *UdpWriter) WriteBytes(line []byte) {
-	_, err := u.conn.Write(line)
-	if err != nil {
-		u.logger.Errorf("Error writing to UDP: %s", err)
+	if u.lineBuffer != nil {
+		u.lineBuffer.WriteBytes(line)
+		return
 	}
+
+	if u.lowLatencyBuffer != nil {
+		u.lowLatencyBuffer.WriteBytes(line)
+		return
+	}
+
+	u.raw.WriteBytes(line)
 }
 
 func (u *UdpWriter) WriteString(line string) {
-	_, err := u.conn.Write([]byte(line))
-	if err != nil {
-		u.logger.Errorf("Error writing to UDP: %s", err)
-	}
+	u.raw.WriteString(line)
 }
 
 func (u *UdpWriter) Close() error {
@@ -92,9 +128,5 @@ func (u *UdpWriter) Close() error {
 	}
 
 	// Close the connection, if it exists
-	if u.conn != nil {
-		return u.conn.Close()
-	}
-
-	return nil
+	return u.raw.Close()
 }

--- a/spectator/writer/udp_writer_test.go
+++ b/spectator/writer/udp_writer_test.go
@@ -192,6 +192,48 @@ func TestUdpWriter_LineBuffer_Write(t *testing.T) {
 	}
 }
 
+func TestUdpWriter_LineBuffer_WriteBytes(t *testing.T) {
+	// Start a local UDP server
+	server, err := net.ListenPacket("udp", "localhost:0")
+	if err != nil {
+		t.Fatalf("Could not start UDP server: %v", err)
+	}
+	defer server.Close()
+
+	// Create a new UDP writer
+	writer, err := NewUdpWriterWithBuffer(server.LocalAddr().String(), logger.NewDefaultLogger(), 20, 5*time.Second)
+	if err != nil {
+		t.Fatalf("Could not create UDP writer: %v", err)
+	}
+
+	// Write messages and overflow the buffer, to trigger a flush
+	writer.WriteBytes([]byte("message1"))
+	writer.WriteBytes([]byte("message2"))
+	writer.WriteBytes([]byte("message3"))
+
+	// Read the overflow metric
+	buffer := make([]byte, 50)
+	_ = server.SetReadDeadline(time.Now().Add(time.Second))
+	n, _, err := server.ReadFrom(buffer)
+	if err != nil {
+		t.Fatalf("Could not read from UDP server: %v", err)
+	}
+	if got, expected := string(buffer[:n]), "c:spectator-go.lineBuffer.overflows:1"; got != expected {
+		t.Errorf("Expected '%s', got '%s'", expected, got)
+	}
+
+	// Read the flushed payload. This used to deadlock when flush() re-entered the buffer.
+	buffer = make([]byte, 50)
+	_ = server.SetReadDeadline(time.Now().Add(time.Second))
+	n, _, err = server.ReadFrom(buffer)
+	if err != nil {
+		t.Fatalf("Could not read from UDP server: %v", err)
+	}
+	if got, expected := string(buffer[:n]), "message1\nmessage2\nmessage3"; got != expected {
+		t.Errorf("Expected '%s', got '%s'", expected, got)
+	}
+}
+
 func TestConcurrentWrites(t *testing.T) {
 	messagesPerThread := 1000
 	writerThreadCount := 4

--- a/spectator/writer/unixgram_writer.go
+++ b/spectator/writer/unixgram_writer.go
@@ -1,26 +1,58 @@
 package writer
 
 import (
-	"github.com/Netflix/spectator-go/v2/spectator/logger"
 	"net"
 	"strings"
 	"time"
+
+	"github.com/Netflix/spectator-go/v2/spectator/logger"
 )
 
 type UnixgramWriter struct {
-	addr             *net.UnixAddr
-	conn             *net.UnixConn
-	logger           logger.Logger
+	raw              *rawUnixgramWriter
 	lineBuffer       *LineBuffer
 	lowLatencyBuffer *LowLatencyBuffer
 }
 
-type unixgramBufferWriter struct {
-	*UnixgramWriter
+type rawUnixgramWriter struct {
+	addr   *net.UnixAddr
+	conn   *net.UnixConn
+	logger logger.Logger
+}
+
+func (u *rawUnixgramWriter) Write(line string) {
+	u.WriteString(line)
+}
+
+func (u *rawUnixgramWriter) WriteBytes(line []byte) {
+	if u.conn != nil {
+		if _, err := u.conn.Write(line); err != nil {
+			u.maybeCloseSocket(err)
+		}
+	} else {
+		u.redialSocket()
+	}
+}
+
+func (u *rawUnixgramWriter) WriteString(line string) {
+	if u.conn != nil {
+		if _, err := u.conn.Write([]byte(line)); err != nil {
+			u.maybeCloseSocket(err)
+		}
+	} else {
+		u.redialSocket()
+	}
+}
+
+func (u *rawUnixgramWriter) Close() error {
+	if u.conn != nil {
+		return u.conn.Close()
+	}
+	return nil
 }
 
 func NewUnixgramWriter(path string, logger logger.Logger) (*UnixgramWriter, error) {
-	return NewUnixgramWriterWithBuffer(path, logger, 0, 5 * time.Second)
+	return NewUnixgramWriterWithBuffer(path, logger, 0, 5*time.Second)
 }
 
 func NewUnixgramWriterWithBuffer(path string, logger logger.Logger, bufferSize int, flushInterval time.Duration) (*UnixgramWriter, error) {
@@ -31,18 +63,25 @@ func NewUnixgramWriterWithBuffer(path string, logger logger.Logger, bufferSize i
 		conn = nil
 	}
 
-	baseWriter := &UnixgramWriter{
+	raw := &rawUnixgramWriter{
 		addr:   addr,
 		conn:   conn,
 		logger: logger,
+	}
+	baseWriter := &UnixgramWriter{
+		raw: raw,
 	}
 
 	var lineBuffer *LineBuffer
 	var lowLatencyBuffer *LowLatencyBuffer
 	if bufferSize > 0 && bufferSize <= 65536 {
-		lineBuffer = NewLineBuffer(&unixgramBufferWriter{baseWriter}, logger, bufferSize, flushInterval)
+		// Buffers flush through the raw socket writer, not UnixgramWriter, to avoid
+		// re-entering buffering logic on WriteBytes/WriteString.
+		lineBuffer = NewLineBuffer(raw, logger, bufferSize, flushInterval)
 	} else if bufferSize > 0 {
-		lowLatencyBuffer = NewLowLatencyBuffer(&unixgramBufferWriter{baseWriter}, logger, bufferSize, flushInterval)
+		// Buffers flush through the raw socket writer, not UnixgramWriter, to avoid
+		// re-entering buffering logic on WriteBytes/WriteString.
+		lowLatencyBuffer = NewLowLatencyBuffer(raw, logger, bufferSize, flushInterval)
 	}
 	baseWriter.lineBuffer = lineBuffer
 	baseWriter.lowLatencyBuffer = lowLatencyBuffer
@@ -51,7 +90,7 @@ func NewUnixgramWriterWithBuffer(path string, logger logger.Logger, bufferSize i
 }
 
 func (u *UnixgramWriter) Write(line string) {
-	u.logger.Debugf("Sending line: %s", line)
+	u.raw.logger.Debugf("Sending line: %s", line)
 
 	if u.lineBuffer != nil {
 		u.lineBuffer.Write(line)
@@ -63,27 +102,25 @@ func (u *UnixgramWriter) Write(line string) {
 		return
 	}
 
-	u.WriteString(line)
+	u.raw.WriteString(line)
 }
 
 func (u *UnixgramWriter) WriteBytes(line []byte) {
-	if u.conn != nil {
-		if _, err := u.conn.Write(line); err != nil {
-			u.maybeCloseSocket(err)
-		}
-	} else {
-		u.redialSocket()
+	if u.lineBuffer != nil {
+		u.lineBuffer.WriteBytes(line)
+		return
 	}
+
+	if u.lowLatencyBuffer != nil {
+		u.lowLatencyBuffer.WriteBytes(line)
+		return
+	}
+
+	u.raw.WriteBytes(line)
 }
 
 func (u *UnixgramWriter) WriteString(line string) {
-	if u.conn != nil {
-		if _, err := u.conn.Write([]byte(line)); err != nil {
-			u.maybeCloseSocket(err)
-		}
-	} else {
-		u.redialSocket()
-	}
+	u.raw.WriteString(line)
 }
 
 // If anything disturbs access to the unix socket, such as a spectatord process restart (or another
@@ -98,7 +135,7 @@ func (u *UnixgramWriter) WriteString(line string) {
 // The addition of reconnect logic to the UnixgramWriter mitigates ongoing issues with unix socket write
 // errors. Some packet delivery failure will occur until it can reconnect. With the reconnect logic in
 // place, the initialization is now more resilient if the unix socket is not available at program start.
-func (u *UnixgramWriter) maybeCloseSocket(err error) {
+func (u *rawUnixgramWriter) maybeCloseSocket(err error) {
 	u.logger.Errorf("failed to write to unix socket: %v\n", err)
 
 	if strings.Contains(err.Error(), "transport endpoint is not connected") {
@@ -111,7 +148,7 @@ func (u *UnixgramWriter) maybeCloseSocket(err error) {
 	}
 }
 
-func (u *UnixgramWriter) redialSocket() {
+func (u *rawUnixgramWriter) redialSocket() {
 	u.logger.Infof("re-dial unix socket")
 
 	conn, err := net.DialUnix("unixgram", nil, u.addr)
@@ -121,7 +158,6 @@ func (u *UnixgramWriter) redialSocket() {
 		u.conn = conn
 	}
 }
-
 
 func (u *UnixgramWriter) Close() error {
 	// Stop flush timer, and flush remaining lines
@@ -135,9 +171,5 @@ func (u *UnixgramWriter) Close() error {
 	}
 
 	// Close the connection
-	if u.conn != nil {
-		return u.conn.Close()
-	}
-
-	return nil
+	return u.raw.Close()
 }

--- a/spectator/writer/unixgram_writer_test.go
+++ b/spectator/writer/unixgram_writer_test.go
@@ -211,3 +211,45 @@ func TestUnixgramWriter_LineBuffer_Write(t *testing.T) {
 	// Allow time for messages to deliver
 	time.Sleep(2 * time.Millisecond)
 }
+
+func TestUnixgramWriter_LineBuffer_WriteBytes(t *testing.T) {
+	// Create server
+	server, msgCh, serverErr := newUnixgramServer()
+	if serverErr != nil {
+		t.Fatalf("Failed to create unixgram server: %v", serverErr)
+	}
+	defer server.Close()
+
+	// Create writer
+	writer, err := NewUnixgramWriterWithBuffer(testUnixgramSocket, logger.NewDefaultLogger(), 20, 5*time.Second)
+	if err != nil {
+		t.Fatalf("Failed to create writer: %v", err)
+	}
+
+	// Write messages and overflow the buffer, to trigger a flush
+	writer.WriteBytes([]byte("message1"))
+	writer.WriteBytes([]byte("message2"))
+	writer.WriteBytes([]byte("message3"))
+
+	expected := "c:spectator-go.lineBuffer.overflows:1"
+	recvMsg, recvErr := readMessage(msgCh)
+	if recvErr != nil {
+		t.Errorf("Failed to receive message: %v", recvErr)
+	}
+	if recvMsg != expected {
+		t.Errorf("Received message '%s' does not match original message '%s'", recvMsg, expected)
+	}
+
+	// This used to deadlock when flush() re-entered the same buffer via WriteBytes.
+	expected = "message1\nmessage2\nmessage3"
+	recvMsg, recvErr = readMessage(msgCh)
+	if recvErr != nil {
+		t.Errorf("Failed to receive message: %v", recvErr)
+	}
+	if recvMsg != expected {
+		t.Errorf("Received message '%s' does not match original message '%s'", recvMsg, expected)
+	}
+
+	// Allow time for messages to deliver
+	time.Sleep(2 * time.Millisecond)
+}


### PR DESCRIPTION
## Summary
- let line-protocol helpers keep their byte slices through the writer boundary via `WriteBytes`
- update buffered UDP and unixgram writer paths so byte writes preserve the same buffering semantics as string writes
- add a targeted write-path benchmark to compare `Write(string)` with `WriteBytes([]byte)` behavior

## Benchmark results
Baseline: #124

```text
name                           old time/op    new time/op    delta
CounterAddCombined-12            510.1ns       478.4ns       -6.21%
CounterAddCombinedPostGC-12      585.6ns       595.5ns          ~
geomean                          546.5ns       533.7ns       -2.35%

name                           old B/op       new B/op      delta
CounterAddCombined-12             768.0         592.0       -22.92%
CounterAddCombinedPostGC-12       769.0         593.0       -22.89%
geomean                           768.5         592.5       -22.90%

name                           old allocs/op  new allocs/op delta
CounterAddCombined-12              5.000         4.000      -20.00%
CounterAddCombinedPostGC-12        5.000         4.000      -20.00%
geomean                             5.000         4.000      -20.00%
```

## Test plan
- [x] `go test ./spectator/meter`
- [x] `go test ./spectator/writer -run '^$'`
- [x] `go test ./spectator/meter -run '^$' -bench 'BenchmarkCounterAddCombined$|BenchmarkCounterAddCombinedPostGC$' -benchmem -count=10`
- [x] `go test ./spectator/meter -run '^$' -bench 'BenchmarkWriteLineInt(Current|Bytes)' -benchmem -count=1`

Made with [Cursor](https://cursor.com)