### PR TITLE
Preserve ordered writes for sampled meters

### DIFF
--- a/spectator/writer/lowlatency_buffer.go
+++ b/spectator/writer/lowlatency_buffer.go
@@ -3,6 +3,7 @@ package writer
 import (
 	"fmt"
 	"runtime"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -20,8 +21,10 @@ const chunkSize = 60 * 1024
 const separator = "\n"
 
 // bufferShard is the atomic unit of buffering, used to store one or more chunks of spectatord
-// protocol lines. Each shard is accessed in round-robin format within either the front buffer
-// or the back buffer, and the number of shards is scaled to the number of CPUs on the system.
+// protocol lines. Order-sensitive meter types are selected deterministically by meter id, so
+// that sequential updates for the same meter land in the same shard and are flushed in the
+// order they were written. Other lines are distributed round-robin across shards. The number
+// of shards is scaled to the number of CPUs on the system.
 // The purpose of this design is to spread buffer access across a reasonable number of mutexes,
 // in order to reduce overall latency when writing to the buffer. The impact of the shard design
 // is less than the impact of the front and back buffer design, but it is still important for
@@ -81,13 +84,18 @@ type LowLatencyBuffer struct {
 	// so that one can be drained for writes to the spectatord socket, while the other can be filled
 	// with writes from the application without contending for the same mutexes. They are swapped back
 	// and forth during periodic flushes, according to the flushInterval.
-	frontBuffers    []*bufferShard
-	backBuffers     []*bufferShard
-	bufferSetSize   int
-	useFrontBuffers atomic.Bool
-	flushInterval   time.Duration
+	frontBuffers  []*bufferShard
+	backBuffers   []*bufferShard
+	bufferSetSize int
+	flushInterval time.Duration
 
-	// Distribute writes across the shards in the active buffer, with a round-robin scheme.
+	// activeBufferState is incremented on every buffer swap. Even values mean the front buffers
+	// are active for application writes, odd values mean the back buffers are active. Writers
+	// verify the state after locking a shard so delayed writes cannot append to a buffer set
+	// that has already been swapped out and flushed.
+	activeBufferState atomic.Uint64
+
+	// Counter used to round-robin shards for commutative meter types and malformed lines.
 	counter uint64
 
 	stopCh chan struct{}
@@ -134,8 +142,6 @@ func NewLowLatencyBuffer(writer Writer, logger logger.Logger, bufferSize int, fl
 		stopCh:        make(chan struct{}),
 	}
 
-	llb.useFrontBuffers.Store(true)
-
 	// Start the flush goroutine
 	llb.wg.Add(1)
 	go llb.flushLoop()
@@ -144,27 +150,45 @@ func NewLowLatencyBuffer(writer Writer, logger logger.Logger, bufferSize int, fl
 }
 
 func (llb *LowLatencyBuffer) Write(line string) {
-	// Pick a shard index across all shards in the active buffer, with a round-robin distribution
-	shardIndex := int(atomic.AddUint64(&llb.counter, 1)) % len(llb.frontBuffers)
+	// Pick a shard deterministically by meter id only for order-sensitive meter types.
+	// Other lines use round-robin distribution to preserve write throughput for hot meters.
+	shardIndex := llb.shardIndexFor(line)
+	lineBytes := []byte(line)
 
-	// Acquire read lock, to check which buffers are active
-	var buffer *bufferShard
-	if llb.useFrontBuffers.Load() {
-		buffer = llb.frontBuffers[shardIndex]
-	} else {
-		buffer = llb.backBuffers[shardIndex]
+	for {
+		state := llb.activeBufferState.Load()
+		buffer := llb.bufferShardForState(state, shardIndex)
+		if llb.writeToActiveShard(buffer, state, lineBytes) {
+			return
+		}
 	}
+}
 
+func (llb *LowLatencyBuffer) bufferShardForState(state uint64, shardIndex int) *bufferShard {
+	if frontBuffersActive(state) {
+		return llb.frontBuffers[shardIndex]
+	}
+	return llb.backBuffers[shardIndex]
+}
+
+func frontBuffersActive(state uint64) bool {
+	return state%2 == 0
+}
+
+func (llb *LowLatencyBuffer) writeToActiveShard(buffer *bufferShard, state uint64, lineBytes []byte) bool {
 	// Add the line to the appropriate chunk in the buffer shard, or drop, if it overflows
 	buffer.mu.Lock()
 	defer buffer.mu.Unlock()
-	lineBytes := []byte(line)
+
+	if llb.activeBufferState.Load() != state {
+		return false
+	}
 
 	// Check if current chunk can fit the new data
 	idx := buffer.getChunkIndexForLine(lineBytes)
 	if idx == -1 {
 		// overflows (drops) are counted in getChunkIndexForLine, for metric reporting
-		return
+		return true
 	}
 
 	// We can write to the selected chunk
@@ -173,6 +197,64 @@ func (llb *LowLatencyBuffer) Write(line string) {
 		buffer.data[buffer.chunkIndex] = append(buffer.data[buffer.chunkIndex], []byte(separator)...)
 	}
 	buffer.data[buffer.chunkIndex] = append(buffer.data[buffer.chunkIndex], lineBytes...)
+	return true
+}
+
+// shardIndexFor returns the shard a protocol line should be written to. Lines for the same
+// order-sensitive meter id always hash to the same shard, so sequential writes preserve order
+// through flush. Other lines use the global counter for round-robin distribution.
+func (llb *LowLatencyBuffer) shardIndexFor(line string) int {
+	numShards := uint32(len(llb.frontBuffers))
+	if key, ok := orderSensitiveMeterIdKey(line); ok {
+		return int(fnv1aHash(key) % numShards)
+	}
+	return int(atomic.AddUint64(&llb.counter, 1) % uint64(numShards))
+}
+
+// orderSensitiveMeterIdKey returns the meter id portion of a spectatord protocol line for
+// meter types where arrival order affects interpretation by spectatord. The protocol line
+// format is "<type>:<id>:<value>" or "<type>,<extra>:<id>:<value>" (e.g. "g,120:..." for
+// gauges with a TTL). The id is the substring between the first and last ':' in the line.
+// Returns ok=false for commutative meter types and malformed lines.
+func orderSensitiveMeterIdKey(line string) (string, bool) {
+	first := strings.IndexByte(line, ':')
+	if first <= 0 {
+		return "", false
+	}
+	if !isOrderSensitiveMeterType(line[:first]) {
+		return "", false
+	}
+	last := strings.LastIndexByte(line, ':')
+	if last <= first {
+		return "", false
+	}
+	return line[first+1 : last], true
+}
+
+// isOrderSensitiveMeterType identifies protocol types that carry absolute samples rather than
+// commutative observations. Reordering these samples can change what spectatord reports.
+func isOrderSensitiveMeterType(symbol string) bool {
+	switch symbol {
+	case "A", "C", "U", "g":
+		return true
+	default:
+		return strings.HasPrefix(symbol, "g,")
+	}
+}
+
+// fnv1aHash is an inline FNV-1a 32-bit hash over a string, written to avoid the allocation
+// that hash/fnv incurs by exposing an io.Writer-style interface.
+func fnv1aHash(s string) uint32 {
+	const (
+		offset32 uint32 = 2166136261
+		prime32  uint32 = 16777619
+	)
+	h := offset32
+	for i := 0; i < len(s); i++ {
+		h ^= uint32(s[i])
+		h *= prime32
+	}
+	return h
 }
 
 // flushLoop runs in a separate goroutine and handles buffer swapping and flushing
@@ -199,12 +281,11 @@ func (llb *LowLatencyBuffer) swapAndFlush() {
 	start := time.Now()
 
 	// Swap the buffer sets, so one can be drained, while the other accepts application writes
-	old := llb.useFrontBuffers.Load()
-	llb.useFrontBuffers.CompareAndSwap(old, !old)
+	state := llb.activeBufferState.Add(1)
 
 	var bufferSet string
 	var buffersToFlush []*bufferShard
-	if llb.useFrontBuffers.Load() {
+	if frontBuffersActive(state) {
 		// Front buffers are now in use for application writes, so flush the back buffers
 		bufferSet = "back"
 		buffersToFlush = llb.backBuffers

--- a/spectator/writer/lowlatency_buffer_bench_test.go
+++ b/spectator/writer/lowlatency_buffer_bench_test.go
@@ -1,0 +1,66 @@
+package writer
+
+import (
+	"runtime"
+	"strconv"
+	"testing"
+	"time"
+)
+
+type discardLogger struct{}
+
+func (discardLogger) Debugf(_ string, _ ...interface{}) {}
+func (discardLogger) Infof(_ string, _ ...interface{})  {}
+func (discardLogger) Errorf(_ string, _ ...interface{}) {}
+
+func newBenchmarkLowLatencyBuffer(b *testing.B) *LowLatencyBuffer {
+	b.Helper()
+
+	shards := runtime.NumCPU()
+	bufferSize := 2 * 16 * chunkSize * shards
+	buffer := NewLowLatencyBuffer(&NoopWriter{}, discardLogger{}, bufferSize, time.Millisecond)
+	b.Cleanup(buffer.Close)
+	return buffer
+}
+
+func benchmarkProtocolLines(prefix string, count int) []string {
+	lines := make([]string, count)
+	for i := range lines {
+		lines[i] = prefix + strconv.Itoa(i) + ":1"
+	}
+	return lines
+}
+
+func BenchmarkLowLatencyBuffer_WriteParallel(b *testing.B) {
+	manyCounters := benchmarkProtocolLines("c:many.counter.", 1024)
+	manyGauges := benchmarkProtocolLines("g:many.gauge.", 1024)
+
+	tests := []struct {
+		name  string
+		lines []string
+	}{
+		{name: "hot_counter_same_id", lines: []string{"c:hot.counter:1"}},
+		{name: "hot_gauge_same_id", lines: []string{"g:hot.gauge:1"}},
+		{name: "many_counters", lines: manyCounters},
+		{name: "many_gauges", lines: manyGauges},
+	}
+
+	for _, test := range tests {
+		b.Run(test.name, func(b *testing.B) {
+			buffer := newBenchmarkLowLatencyBuffer(b)
+			mask := len(test.lines) - 1
+
+			b.ReportAllocs()
+			b.SetBytes(int64(len(test.lines[0])))
+			b.ResetTimer()
+
+			b.RunParallel(func(pb *testing.PB) {
+				i := 0
+				for pb.Next() {
+					buffer.Write(test.lines[i&mask])
+					i++
+				}
+			})
+		})
+	}
+}

--- a/spectator/writer/lowlatency_buffer_test.go
+++ b/spectator/writer/lowlatency_buffer_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/Netflix/spectator-go/v2/spectator/logger"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -75,16 +76,16 @@ func TestLowLatencyBuffer_FrontBuffersFlushFirst(t *testing.T) {
 	buffer := NewLowLatencyBuffer(memWriter, logger.NewDefaultLogger(), bufferSize, 3*time.Minute)
 	defer buffer.Close()
 
-	if buffer.useFrontBuffers.Load() != true {
-		t.Errorf("Expected useFrontBuffers to be true")
+	if !frontBuffersActive(buffer.activeBufferState.Load()) {
+		t.Errorf("Expected front buffers to be active")
 	}
 
 	// Ensure that buffer swapping and flushing logic is correct
 	buffer.Write("message1")
 	buffer.swapAndFlush()
 
-	if buffer.useFrontBuffers.Load() != false {
-		t.Errorf("Expected useFrontBuffers to be false")
+	if frontBuffersActive(buffer.activeBufferState.Load()) {
+		t.Errorf("Expected back buffers to be active")
 	}
 
 	lines := splitAndFilterMetricLines(memWriter)
@@ -166,6 +167,195 @@ func TestLowLatencyBuffer_ChunkBoundaries_MaxSize(t *testing.T) {
 	}
 }
 
+func TestLowLatencyBuffer_PreservesOrderForSameMeterId(t *testing.T) {
+	memWriter := &MemoryWriter{}
+	shards := runtime.NumCPU()
+	bufferSize := 2 * 2 * chunkSize * shards
+	buffer := NewLowLatencyBuffer(memWriter, logger.NewDefaultLogger(), bufferSize, 3*time.Minute)
+	defer buffer.Close()
+
+	buffer.Write("g:test.metric,worker=lineage:1.000000")
+	buffer.Write("g:test.metric,worker=lineage:0.000000")
+
+	buffer.swapAndFlush()
+
+	lines := splitAndFilterMetricLines(memWriter)
+	if len(lines) != 2 {
+		t.Fatalf("Expected 2 lines, got %d: %v", len(lines), lines)
+	}
+	if lines[0] != "g:test.metric,worker=lineage:1.000000" {
+		t.Errorf("Expected first line to be g:test.metric,worker=lineage:1.000000, got %s", lines[0])
+	}
+	if lines[1] != "g:test.metric,worker=lineage:0.000000" {
+		t.Errorf("Expected second line to be g:test.metric,worker=lineage:0.000000, got %s", lines[1])
+	}
+}
+
+func TestLowLatencyBuffer_PreservesPerIdOrderInterleaved(t *testing.T) {
+	memWriter := &MemoryWriter{}
+	shards := runtime.NumCPU()
+	bufferSize := 2 * 2 * chunkSize * shards
+	buffer := NewLowLatencyBuffer(memWriter, logger.NewDefaultLogger(), bufferSize, 3*time.Minute)
+	defer buffer.Close()
+
+	writes := []string{"g:a:1", "g:b:1", "g:a:0", "g:b:0"}
+	for _, w := range writes {
+		buffer.Write(w)
+	}
+
+	buffer.swapAndFlush()
+
+	lines := splitAndFilterMetricLines(memWriter)
+
+	var aLines, bLines []string
+	for _, line := range lines {
+		switch {
+		case strings.HasPrefix(line, "g:a:"):
+			aLines = append(aLines, line)
+		case strings.HasPrefix(line, "g:b:"):
+			bLines = append(bLines, line)
+		}
+	}
+
+	wantA := []string{"g:a:1", "g:a:0"}
+	wantB := []string{"g:b:1", "g:b:0"}
+	if !slices.Equal(aLines, wantA) {
+		t.Errorf("Expected per-id order for a to be %v, got %v", wantA, aLines)
+	}
+	if !slices.Equal(bLines, wantB) {
+		t.Errorf("Expected per-id order for b to be %v, got %v", wantB, bLines)
+	}
+}
+
+func TestLowLatencyBuffer_RejectsStaleShardSelectionAfterSwap(t *testing.T) {
+	memWriter := &MemoryWriter{}
+	shards := runtime.NumCPU()
+	bufferSize := 2 * 2 * chunkSize * shards
+	buffer := NewLowLatencyBuffer(memWriter, logger.NewDefaultLogger(), bufferSize, 3*time.Minute)
+	defer buffer.Close()
+
+	staleLine := "g:swap.race:1"
+	newLine := "g:swap.race:2"
+	shardIndex := buffer.shardIndexFor(staleLine)
+	staleState := buffer.activeBufferState.Load()
+	staleShard := buffer.bufferShardForState(staleState, shardIndex)
+
+	buffer.swapAndFlush()
+	buffer.Write(newLine)
+	buffer.swapAndFlush()
+
+	if !frontBuffersActive(buffer.activeBufferState.Load()) {
+		t.Fatalf("Expected front buffers to be active after two swaps")
+	}
+	if buffer.writeToActiveShard(staleShard, staleState, []byte(staleLine)) {
+		t.Fatal("Expected stale buffer selection to be rejected")
+	}
+
+	buffer.swapAndFlush()
+
+	lines := splitAndFilterMetricLines(memWriter)
+	if len(lines) != 1 {
+		t.Fatalf("Expected only the newer line to be flushed, got %d lines: %v", len(lines), lines)
+	}
+	if lines[0] != newLine {
+		t.Fatalf("Expected flushed line %q, got %q", newLine, lines[0])
+	}
+}
+
+func TestLowLatencyBuffer_OrderSensitiveMeterIdKey(t *testing.T) {
+	tests := []struct {
+		line string
+		key  string
+		ok   bool
+	}{
+		{line: "g:test.metric:1", key: "test.metric", ok: true},
+		{line: "g,60:test.metric:1", key: "test.metric", ok: true},
+		{line: "A:test.metric:1", key: "test.metric", ok: true},
+		{line: "C:test.metric:1", key: "test.metric", ok: true},
+		{line: "U:test.metric:1", key: "test.metric", ok: true},
+		{line: "c:test.metric:1", ok: false},
+		{line: "d:test.metric:1", ok: false},
+		{line: "D:test.metric:1", ok: false},
+		{line: "t:test.metric:1", ok: false},
+		{line: "T:test.metric:1", ok: false},
+		{line: "m:test.metric:1", ok: false},
+		{line: "message=1", ok: false},
+		{line: "g:test.metric", ok: false},
+		{line: "gauge:test.metric:1", ok: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.line, func(t *testing.T) {
+			key, ok := orderSensitiveMeterIdKey(test.line)
+			if ok != test.ok {
+				t.Fatalf("Expected ok=%t, got %t", test.ok, ok)
+			}
+			if key != test.key {
+				t.Fatalf("Expected key %q, got %q", test.key, key)
+			}
+		})
+	}
+}
+
+func TestLowLatencyBuffer_RoundRobinsSameCounterId(t *testing.T) {
+	shards := runtime.NumCPU()
+	if shards < 2 {
+		t.Skip("Need at least 2 CPUs to test shard distribution")
+	}
+
+	memWriter := &MemoryWriter{}
+	bufferSize := 2 * 2 * chunkSize * shards
+	buffer := NewLowLatencyBuffer(memWriter, logger.NewDefaultLogger(), bufferSize, 3*time.Minute)
+	defer buffer.Close()
+
+	for i := 0; i < shards*2; i++ {
+		buffer.Write("c:hot.counter:1")
+	}
+
+	shardsWithData := 0
+	for _, shard := range buffer.frontBuffers {
+		shard.mu.Lock()
+		if len(shard.data[0]) > 0 {
+			shardsWithData++
+		}
+		shard.mu.Unlock()
+	}
+
+	if shardsWithData < 2 {
+		t.Errorf("Expected same-id counter writes to round-robin across shards, got %d shard(s) with data", shardsWithData)
+	}
+}
+
+func TestLowLatencyBuffer_DistributesIdsAcrossShards(t *testing.T) {
+	shards := runtime.NumCPU()
+	if shards < 2 {
+		t.Skip("Need at least 2 CPUs to test shard distribution")
+	}
+
+	memWriter := &MemoryWriter{}
+	bufferSize := 2 * 2 * chunkSize * shards
+	buffer := NewLowLatencyBuffer(memWriter, logger.NewDefaultLogger(), bufferSize, 3*time.Minute)
+	defer buffer.Close()
+
+	numIds := shards * 8
+	for i := 0; i < numIds; i++ {
+		buffer.Write(fmt.Sprintf("g:metric.%d:1", i))
+	}
+
+	shardsWithData := 0
+	for _, shard := range buffer.frontBuffers {
+		shard.mu.Lock()
+		if len(shard.data[0]) > 0 {
+			shardsWithData++
+		}
+		shard.mu.Unlock()
+	}
+
+	if shardsWithData < 2 {
+		t.Errorf("Expected at least 2 shards to have data when writing %d distinct ids across %d shards, got %d", numIds, shards, shardsWithData)
+	}
+}
+
 func TestLowLatencyBuffer_ChunkBoundaries_OverMaxSizeIsDropped(t *testing.T) {
 	// Create a buffer instance with a long flush interval timer, to allow for manual flush trigger
 	memWriter := &MemoryWriter{}
@@ -177,7 +367,7 @@ func TestLowLatencyBuffer_ChunkBoundaries_OverMaxSizeIsDropped(t *testing.T) {
 	// Fill all chunks with an over max size message
 	for i := 0; i < 2; i++ {
 		for j := 0; j < shards; j++ {
-			msg := strings.Repeat("x", chunkSize + 1)
+			msg := strings.Repeat("x", chunkSize+1)
 			buffer.Write(msg)
 		}
 	}


### PR DESCRIPTION
LowLatencyBuffer previously round-robined every write across shards. That preserved throughput for hot counters, but it could reorder updates for gauges and other absolute-sample meters where spectatord uses arrival order.

Route only order-sensitive meter types to shards by meter id: gauges, TTL gauges, age gauges, and monotonic counters. Commutative types such as counters, timers, distributions, and max gauges continue to use round-robin shard selection so hot counter workloads do not collapse onto one shard mutex.

Replace the active front/back bool with an atomic buffer generation. Writers verify the generation after locking the shard and retry if a swap happened, preventing delayed writes from appending to a buffer set that was already swapped out and flushed.

Add regression coverage for per-id gauge ordering, same-id counter round-robin behavior, and stale shard selections across swaps. Add parallel LowLatencyBuffer benchmarks for hot counters, hot gauges, and many-id workloads.

Local short run:

  ```text
  go test ./spectator/writer -bench 'BenchmarkLowLatencyBuffer_WriteParallel' -benchtime=200ms -run '^$'

  hot_counter_same_id   62.72 ns/op
  hot_gauge_same_id    183.8 ns/op
  many_counters         61.41 ns/op
  many_gauges           17.29 ns/op
```