### PR TITLE
Reduce metric emission and construction overhead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .idea/
 CLAUDE.md
+
+# Go test binaries and profiles
+*.test
+*.prof

--- a/spectator/meter/age_gauge.go
+++ b/spectator/meter/age_gauge.go
@@ -1,8 +1,6 @@
 package meter
 
 import (
-	"strconv"
-
 	"github.com/Netflix/spectator-go/v2/spectator/writer"
 )
 
@@ -24,19 +22,27 @@ func NewAgeGauge(id *Id, writer writer.Writer) *AgeGauge {
 	return &AgeGauge{id, writer, "A:" + id.spectatordId + ":"}
 }
 
-// MeterId returns the meter identifier.
+// NewAgeGaugeDirect generates a new age gauge directly from a name and tags,
+// without allocating an *Id or copying the tags map. commonTags carries the
+// registry's extraCommonTags.
+func NewAgeGaugeDirect(name string, tags, commonTags map[string]string, writer writer.Writer) *AgeGauge {
+	return &AgeGauge{nil, writer, buildLinePrefix("A", name, tags, commonTags)}
+}
+
+// MeterId returns the meter identifier, reconstructing it from the line prefix
+// if the gauge was created directly from a name and tags.
 func (g *AgeGauge) MeterId() *Id {
-	return g.id
+	return resolveMeterId(g.id, g.linePrefix)
 }
 
 // Set records the current time in seconds since the epoch.
 func (g *AgeGauge) Set(seconds int64) {
 	if seconds >= 0 {
-		g.writer.Write(g.linePrefix + strconv.FormatInt(seconds, 10))
+		g.writer.WriteInt(g.linePrefix, seconds)
 	}
 }
 
 // Now records the current time in epoch seconds, using a spectatord feature.
 func (g *AgeGauge) Now() {
-	g.writer.Write(g.linePrefix + "0")
+	g.writer.WriteLine(g.linePrefix, "0")
 }

--- a/spectator/meter/counter.go
+++ b/spectator/meter/counter.go
@@ -1,8 +1,6 @@
 package meter
 
 import (
-	"strconv"
-
 	"github.com/Netflix/spectator-go/v2/spectator/writer"
 )
 
@@ -24,26 +22,34 @@ func NewCounter(id *Id, writer writer.Writer) *Counter {
 	return &Counter{id, writer, "c:" + id.spectatordId + ":"}
 }
 
-// MeterId returns the meter identifier.
+// NewCounterDirect generates a new counter directly from a name and tags,
+// without allocating an *Id or copying the tags map. commonTags carries the
+// registry's extraCommonTags. MeterId reconstructs an Id on demand.
+func NewCounterDirect(name string, tags, commonTags map[string]string, writer writer.Writer) *Counter {
+	return &Counter{nil, writer, buildLinePrefix("c", name, tags, commonTags)}
+}
+
+// MeterId returns the meter identifier, reconstructing it from the line prefix
+// if the counter was created directly from a name and tags.
 func (c *Counter) MeterId() *Id {
-	return c.id
+	return resolveMeterId(c.id, c.linePrefix)
 }
 
 // Increment increments the counter.
 func (c *Counter) Increment() {
-	c.writer.Write(c.linePrefix + "1")
+	c.writer.WriteLine(c.linePrefix, "1")
 }
 
 // Add adds an int64 delta to the current measurement.
 func (c *Counter) Add(delta int64) {
 	if delta > 0 {
-		c.writer.Write(c.linePrefix + strconv.FormatInt(delta, 10))
+		c.writer.WriteInt(c.linePrefix, delta)
 	}
 }
 
 // AddFloat adds a float64 delta to the current measurement.
 func (c *Counter) AddFloat(delta float64) {
 	if delta > 0.0 {
-		c.writer.Write(c.linePrefix + strconv.FormatFloat(delta, 'f', 6, 64))
+		c.writer.WriteFloat(c.linePrefix, delta)
 	}
 }

--- a/spectator/meter/dist_summary.go
+++ b/spectator/meter/dist_summary.go
@@ -1,8 +1,6 @@
 package meter
 
 import (
-	"strconv"
-
 	"github.com/Netflix/spectator-go/v2/spectator/writer"
 )
 
@@ -25,14 +23,22 @@ func NewDistributionSummary(id *Id, writer writer.Writer) *DistributionSummary {
 	return &DistributionSummary{id, writer, "d:" + id.spectatordId + ":"}
 }
 
-// MeterId returns the meter identifier.
+// NewDistributionSummaryDirect generates a new distribution summary directly from
+// a name and tags, without allocating an *Id or copying the tags map. commonTags
+// carries the registry's extraCommonTags.
+func NewDistributionSummaryDirect(name string, tags, commonTags map[string]string, writer writer.Writer) *DistributionSummary {
+	return &DistributionSummary{nil, writer, buildLinePrefix("d", name, tags, commonTags)}
+}
+
+// MeterId returns the meter identifier, reconstructing it from the line prefix
+// if the summary was created directly from a name and tags.
 func (d *DistributionSummary) MeterId() *Id {
-	return d.id
+	return resolveMeterId(d.id, d.linePrefix)
 }
 
 // Record records a value to track within the distribution.
 func (d *DistributionSummary) Record(amount int64) {
 	if amount >= 0 {
-		d.writer.Write(d.linePrefix + strconv.FormatInt(amount, 10))
+		d.writer.WriteInt(d.linePrefix, amount)
 	}
 }

--- a/spectator/meter/emit_buffer_bench_test.go
+++ b/spectator/meter/emit_buffer_bench_test.go
@@ -1,0 +1,121 @@
+package meter
+
+// End-to-end emit benchmarks: meter -> real LowLatencyBuffer (backed by a
+// NoopWriter so we exercise the buffer append path without socket I/O).
+// Uses only the public Counter API, so the loop body is identical before and
+// after the WriteLine interface extension.
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/Netflix/spectator-go/v2/spectator/writer"
+)
+
+type emitQuietLogger struct{}
+
+func (emitQuietLogger) Debugf(string, ...interface{}) {}
+func (emitQuietLogger) Infof(string, ...interface{})  {}
+func (emitQuietLogger) Errorf(string, ...interface{}) {}
+
+// bufWriter adapts a LowLatencyBuffer to the Writer interface (its Close has no
+// error return).
+type bufWriter struct{ b *writer.LowLatencyBuffer }
+
+func (w *bufWriter) Write(line string)                   { w.b.Write(line) }
+func (w *bufWriter) WriteLine(prefix, value string)      { w.b.WriteLine(prefix, value) }
+func (w *bufWriter) WriteInt(prefix string, v int64)     { w.b.WriteInt(prefix, v) }
+func (w *bufWriter) WriteUint(prefix string, v uint64)   { w.b.WriteUint(prefix, v) }
+func (w *bufWriter) WriteFloat(prefix string, v float64) { w.b.WriteFloat(prefix, v) }
+func (w *bufWriter) WriteBytes(line []byte)              { w.b.Write(string(line)) }
+func (w *bufWriter) WriteString(line string)             { w.b.Write(line) }
+func (w *bufWriter) Close() error                        { w.b.Close(); return nil }
+
+func newBenchBuffer(b *testing.B) *bufWriter {
+	b.Helper()
+	shards := runtime.NumCPU()
+	bufferSize := 2 * 16 * 60 * 1024 * shards
+	buf := writer.NewLowLatencyBuffer(&writer.NoopWriter{}, emitQuietLogger{}, bufferSize, time.Millisecond)
+	w := &bufWriter{buf}
+	b.Cleanup(func() { w.Close() })
+	return w
+}
+
+var emitBenchTags = map[string]string{
+	"app":    "gandalfAgent",
+	"result": "allowed",
+	"policy": "explicit",
+}
+
+// Cached counter (constructed once), Increment in the loop — isolates the emit path.
+func BenchmarkEmitBuffer_Counter_Increment(b *testing.B) {
+	c := NewCounter(NewId("gandalfAgent.authzEngine.appAuthzResult", emitBenchTags), newBenchBuffer(b))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.Increment()
+	}
+}
+
+// Cached counter, Add(delta) in the loop — value requires formatting.
+func BenchmarkEmitBuffer_Counter_Add(b *testing.B) {
+	c := NewCounter(NewId("gandalfAgent.authzEngine.appAuthzResult", emitBenchTags), newBenchBuffer(b))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.Add(int64(i) + 1)
+	}
+}
+
+// Cached gauge, Set(float) in the loop.
+func BenchmarkEmitBuffer_Gauge_Set(b *testing.B) {
+	g := NewGauge(NewId("gandalfAgent.gauge", emitBenchTags), newBenchBuffer(b))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		g.Set(3.14159)
+	}
+}
+
+// Cached timer, Record in the loop.
+func BenchmarkEmitBuffer_Timer_Record(b *testing.B) {
+	t := NewTimer(NewId("gandalfAgent.timer", emitBenchTags), newBenchBuffer(b))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		t.Record(time.Duration(i) * time.Millisecond)
+	}
+}
+
+// Cached distribution summary, Record in the loop.
+func BenchmarkEmitBuffer_DistSummary_Record(b *testing.B) {
+	d := NewDistributionSummary(NewId("gandalfAgent.distsummary", emitBenchTags), newBenchBuffer(b))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		d.Record(int64(i))
+	}
+}
+
+// Construct-per-call (gandalf's actual pattern) over a real buffer, via NewId
+// (the WithId path) for comparison.
+func BenchmarkEmitBuffer_Counter_ConstructPerCall(b *testing.B) {
+	w := newBenchBuffer(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		NewCounter(NewId("gandalfAgent.authzEngine.appAuthzResult", emitBenchTags), w).Increment()
+	}
+}
+
+// Construct-per-call via the direct (name, tags) path — what registry.Counter
+// now uses. No Id, no tag-map copy.
+func BenchmarkEmitBuffer_Counter_ConstructPerCall_Direct(b *testing.B) {
+	w := newBenchBuffer(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		NewCounterDirect("gandalfAgent.authzEngine.appAuthzResult", emitBenchTags, nil, w).Increment()
+	}
+}

--- a/spectator/meter/gauge.go
+++ b/spectator/meter/gauge.go
@@ -2,7 +2,6 @@ package meter
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/Netflix/spectator-go/v2/spectator/writer"
 	"time"
@@ -32,18 +31,31 @@ func NewGaugeWithTTL(id *Id, writer writer.Writer, ttl time.Duration) *Gauge {
 	return &Gauge{id, writer, fmt.Sprintf("g,%d", int(ttl.Seconds())) + ":" + id.spectatordId + ":"}
 }
 
-// MeterId returns the meter identifier.
+// NewGaugeDirect generates a new gauge directly from a name and tags, without
+// allocating an *Id or copying the tags map. commonTags carries the registry's
+// extraCommonTags.
+func NewGaugeDirect(name string, tags, commonTags map[string]string, writer writer.Writer) *Gauge {
+	return &Gauge{nil, writer, buildLinePrefix("g", name, tags, commonTags)}
+}
+
+// NewGaugeDirectWithTTL generates a new gauge with a ttl directly from a name and tags.
+func NewGaugeDirectWithTTL(name string, tags, commonTags map[string]string, writer writer.Writer, ttl time.Duration) *Gauge {
+	return &Gauge{nil, writer, buildLinePrefix(fmt.Sprintf("g,%d", int(ttl.Seconds())), name, tags, commonTags)}
+}
+
+// MeterId returns the meter identifier, reconstructing it from the line prefix
+// if the gauge was created directly from a name and tags.
 func (g *Gauge) MeterId() *Id {
-	return g.id
+	return resolveMeterId(g.id, g.linePrefix)
 }
 
 // Set records the current value.
 func (g *Gauge) Set(value float64) {
-	g.writer.Write(g.linePrefix + strconv.FormatFloat(value, 'f', 6, 64))
+	g.writer.WriteFloat(g.linePrefix, value)
 }
 
 // SetInt records the current value as an integer, avoiding the overhead of
 // float64 conversion and formatting.
 func (g *Gauge) SetInt(value int64) {
-	g.writer.Write(g.linePrefix + strconv.FormatInt(value, 10))
+	g.writer.WriteInt(g.linePrefix, value)
 }

--- a/spectator/meter/id.go
+++ b/spectator/meter/id.go
@@ -138,29 +138,119 @@ func (id *Id) WithTags(tags map[string]string) *Id {
 	return newId(id.name, newTags)
 }
 
+// writeSpectatorId writes the sanitized meter id ("name,key=value,...") to sb.
+// tags and commonTags are merged with commonTags taking precedence on key
+// collisions, matching Registry.NewId followed by Id.WithTags(extraCommonTags).
+// commonTags may be nil. This is the single serializer shared by toSpectatorId
+// (WithId path) and buildLinePrefix (direct path), so both entry points always
+// produce the same wire format.
+func writeSpectatorId(sb *strings.Builder, name string, tags, commonTags map[string]string) {
+	writeSanitized(sb, name)
+
+	// Caller tags, except any key overridden by a common tag.
+	for k, v := range tags {
+		if _, overridden := commonTags[k]; overridden {
+			continue
+		}
+		sb.WriteByte(',')
+		writeSanitized(sb, k)
+		sb.WriteByte('=')
+		writeSanitized(sb, v)
+	}
+
+	// Common tags (win on key collision).
+	for k, v := range commonTags {
+		sb.WriteByte(',')
+		writeSanitized(sb, k)
+		sb.WriteByte('=')
+		writeSanitized(sb, v)
+	}
+}
+
 func toSpectatorId(name string, tags map[string]string) string {
 	sb := builderPool.Get().(*strings.Builder)
 	sb.Reset()
 	defer builderPool.Put(sb)
 
 	// Pre-size: name + per-tag overhead (comma + key + equals + value).
-	estimatedSize := len(name) + len(tags)*40
-	sb.Grow(estimatedSize)
-
-	writeSanitized(sb, name)
-
-	// Append sanitized keys and values.
-	for k, v := range tags {
-		sb.WriteString(",")
-		writeSanitized(sb, k)
-		sb.WriteString("=")
-		writeSanitized(sb, v)
-	}
-
+	sb.Grow(len(name) + len(tags)*40)
+	writeSpectatorId(sb, name, tags, nil)
 	return sb.String()
 }
 
+// buildLinePrefix assembles a meter's spectatord line prefix,
+// "<symbol>:<sanitized id>:", in a single builder pass. It lets a meter be
+// constructed from a name and tags without allocating an *Id, copying the tags
+// map, or materializing a separate spectatordId string: the only allocation is
+// the returned prefix. commonTags carries the registry's extraCommonTags and is
+// merged in (commonTags win on collision), so meters built this way include the
+// same infrastructure tags as the WithId path. The symbol is the spectatord
+// meter type (e.g. "c", "g", or "g,120" for a gauge with a TTL).
+func buildLinePrefix(symbol, name string, tags, commonTags map[string]string) string {
+	sb := builderPool.Get().(*strings.Builder)
+	sb.Reset()
+	defer builderPool.Put(sb)
+
+	// symbol + ':' + name + per-tag (",key=value") + trailing ':'
+	sb.Grow(len(symbol) + 2 + len(name) + (len(tags)+len(commonTags))*40)
+	sb.WriteString(symbol)
+	sb.WriteByte(':')
+	writeSpectatorId(sb, name, tags, commonTags)
+	sb.WriteByte(':')
+	return sb.String()
+}
+
+// resolveMeterId returns id when the meter was built with one (the WithId path),
+// otherwise reconstructs an *Id from linePrefix (the direct path). Shared by
+// every meter's MeterId().
+func resolveMeterId(id *Id, linePrefix string) *Id {
+	if id != nil {
+		return id
+	}
+	return idFromLinePrefix(linePrefix)
+}
+
+// idFromLinePrefix reconstructs an *Id from a meter line prefix of the form
+// "<symbol>:<spectatordId>:". Meters built directly from a name and tags do not
+// retain an Id, so this rebuilds one on demand for the rarely-used MeterId().
+// The spectatordId is the substring between the first and last ':' — meter type
+// symbols and sanitized names/tags never contain ':'. The returned tags are the
+// sanitized "key=value" pairs; original pre-sanitization tag text is not
+// recoverable from the prefix.
+func idFromLinePrefix(linePrefix string) *Id {
+	first := strings.IndexByte(linePrefix, ':')
+	last := strings.LastIndexByte(linePrefix, ':')
+	if first < 0 || last <= first {
+		return &Id{name: linePrefix}
+	}
+	spectatordId := linePrefix[first+1 : last]
+
+	name := spectatordId
+	var tags map[string]string
+	if comma := strings.IndexByte(spectatordId, ','); comma >= 0 {
+		name = spectatordId[:comma]
+		tags = make(map[string]string)
+		for _, pair := range strings.Split(spectatordId[comma+1:], ",") {
+			if eq := strings.IndexByte(pair, '='); eq >= 0 {
+				tags[pair[:eq]] = pair[eq+1:]
+			}
+		}
+	}
+	return &Id{name: name, tags: tags, spectatordId: spectatordId}
+}
+
 func writeSanitized(sb *strings.Builder, input string) {
+	// Fast path: every valid character is single-byte ASCII, so if no byte is
+	// invalid the input contains no multi-byte runes and needs no rewriting.
+	// Write it in one shot, avoiding a per-rune UTF-8 decode + re-encode. This
+	// is the common case, since metric names and tags are usually already clean.
+	if isCleanForProtocol(input) {
+		sb.WriteString(input)
+		return
+	}
+
+	// Slow path: at least one character must be replaced. Range over runes so
+	// each invalid rune (which may be multi-byte) collapses to a single '_'.
 	for _, r := range input {
 		if !isValidCharacter(r) {
 			sb.WriteRune('_')
@@ -168,6 +258,19 @@ func writeSanitized(sb *strings.Builder, input string) {
 			sb.WriteRune(r)
 		}
 	}
+}
+
+// isCleanForProtocol reports whether input is composed entirely of valid
+// characters and therefore requires no sanitization. It scans bytes rather than
+// runes: any byte >= 0x80 (part of a multi-byte rune) fails isValidCharacter,
+// correctly routing non-ASCII input to the rewriting slow path.
+func isCleanForProtocol(input string) bool {
+	for i := 0; i < len(input); i++ {
+		if !isValidCharacter(rune(input[i])) {
+			return false
+		}
+	}
+	return true
 }
 
 func isValidCharacter(r rune) bool {

--- a/spectator/meter/id_test.go
+++ b/spectator/meter/id_test.go
@@ -7,7 +7,44 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/Netflix/spectator-go/v2/spectator/writer"
 )
+
+func TestNewCounterDirect_MeterIdMatchesWithId(t *testing.T) {
+	w := &writer.NoopWriter{}
+	tags := map[string]string{"app": "foo", "region": "us-east-1", "env": "prod"}
+
+	viaId := NewCounter(NewId("my.counter", tags), w)
+	direct := NewCounterDirect("my.counter", tags, nil, w)
+
+	// Canonical identity must match. MapKey sorts tags, so it is order-independent
+	// (spectatordId tag order follows map iteration order and is not stable).
+	got := direct.MeterId()
+	if got.MapKey() != viaId.MeterId().MapKey() {
+		t.Errorf("MapKey mismatch: %q vs %q", got.MapKey(), viaId.MeterId().MapKey())
+	}
+
+	// MeterId() reconstructed from the prefix must recover the name and (for
+	// clean input) the original tags.
+	if got.Name() != "my.counter" {
+		t.Errorf("name mismatch: got %q", got.Name())
+	}
+	if !reflect.DeepEqual(got.Tags(), tags) {
+		t.Errorf("tags mismatch: got %v want %v", got.Tags(), tags)
+	}
+}
+
+func TestNewCounterDirect_MeterIdNoTags(t *testing.T) {
+	direct := NewCounterDirect("my.counter", nil, nil, &writer.NoopWriter{})
+	got := direct.MeterId()
+	if got.Name() != "my.counter" {
+		t.Errorf("name mismatch: got %q", got.Name())
+	}
+	if len(got.Tags()) != 0 {
+		t.Errorf("expected no tags, got %v", got.Tags())
+	}
+}
 
 func TestId_mapKey(t *testing.T) {
 	id := NewId("foo", nil)
@@ -142,6 +179,17 @@ func TestToSpectatorId_InvalidTags(t *testing.T) {
 
 	if result != expected1 && result != expected2 {
 		t.Errorf("Expected '%s' or '%s', got '%s'", expected1, expected2, result)
+	}
+}
+
+// TestToSpectatorId_MultiByte verifies that multi-byte (non-ASCII) runes each
+// collapse to a single '_', which exercises the writeSanitized slow path and
+// confirms the byte-scan fast path correctly routes non-ASCII input to it.
+func TestToSpectatorId_MultiByte(t *testing.T) {
+	// "café" -> c,a,f valid; 'é' (2 bytes) invalid -> one '_'. "€5" -> '€' (3 bytes) -> '_', '5' valid.
+	result := toSpectatorId("café", map[string]string{"k": "€5"})
+	if expected := "caf_,k=_5"; result != expected {
+		t.Errorf("Expected %q, got %q", expected, result)
 	}
 }
 

--- a/spectator/meter/max_gauge.go
+++ b/spectator/meter/max_gauge.go
@@ -1,8 +1,6 @@
 package meter
 
 import (
-	"strconv"
-
 	"github.com/Netflix/spectator-go/v2/spectator/writer"
 )
 
@@ -25,12 +23,20 @@ func NewMaxGauge(id *Id, writer writer.Writer) *MaxGauge {
 	return &MaxGauge{id, writer, "m:" + id.spectatordId + ":"}
 }
 
-// MeterId returns the meter identifier.
+// NewMaxGaugeDirect generates a new max gauge directly from a name and tags,
+// without allocating an *Id or copying the tags map. commonTags carries the
+// registry's extraCommonTags.
+func NewMaxGaugeDirect(name string, tags, commonTags map[string]string, writer writer.Writer) *MaxGauge {
+	return &MaxGauge{nil, writer, buildLinePrefix("m", name, tags, commonTags)}
+}
+
+// MeterId returns the meter identifier, reconstructing it from the line prefix
+// if the gauge was created directly from a name and tags.
 func (g *MaxGauge) MeterId() *Id {
-	return g.id
+	return resolveMeterId(g.id, g.linePrefix)
 }
 
 // Set records the current value.
 func (g *MaxGauge) Set(value float64) {
-	g.writer.Write(g.linePrefix + strconv.FormatFloat(value, 'f', 6, 64))
+	g.writer.WriteFloat(g.linePrefix, value)
 }

--- a/spectator/meter/monotonic_counter.go
+++ b/spectator/meter/monotonic_counter.go
@@ -1,8 +1,6 @@
 package meter
 
 import (
-	"strconv"
-
 	"github.com/Netflix/spectator-go/v2/spectator/writer"
 )
 
@@ -29,12 +27,20 @@ func NewMonotonicCounter(id *Id, writer writer.Writer) *MonotonicCounter {
 	return &MonotonicCounter{id, writer, "C:" + id.spectatordId + ":"}
 }
 
-// MeterId returns the meter identifier.
+// NewMonotonicCounterDirect generates a new monotonic counter directly from a
+// name and tags, without allocating an *Id or copying the tags map. commonTags
+// carries the registry's extraCommonTags.
+func NewMonotonicCounterDirect(name string, tags, commonTags map[string]string, writer writer.Writer) *MonotonicCounter {
+	return &MonotonicCounter{nil, writer, buildLinePrefix("C", name, tags, commonTags)}
+}
+
+// MeterId returns the meter identifier, reconstructing it from the line prefix
+// if the counter was created directly from a name and tags.
 func (c *MonotonicCounter) MeterId() *Id {
-	return c.id
+	return resolveMeterId(c.id, c.linePrefix)
 }
 
 // Set sets a value as the current measurement; spectatord calculates the delta.
 func (c *MonotonicCounter) Set(value float64) {
-	c.writer.Write(c.linePrefix + strconv.FormatFloat(value, 'f', 6, 64))
+	c.writer.WriteFloat(c.linePrefix, value)
 }

--- a/spectator/meter/monotonic_counter_uint.go
+++ b/spectator/meter/monotonic_counter_uint.go
@@ -1,8 +1,6 @@
 package meter
 
 import (
-	"strconv"
-
 	"github.com/Netflix/spectator-go/v2/spectator/writer"
 )
 
@@ -29,12 +27,20 @@ func NewMonotonicCounterUint(id *Id, writer writer.Writer) *MonotonicCounterUint
 	return &MonotonicCounterUint{id, writer, "U:" + id.spectatordId + ":"}
 }
 
-// MeterId returns the meter identifier.
+// NewMonotonicCounterUintDirect generates a new uint monotonic counter directly
+// from a name and tags, without allocating an *Id or copying the tags map.
+// commonTags carries the registry's extraCommonTags.
+func NewMonotonicCounterUintDirect(name string, tags, commonTags map[string]string, writer writer.Writer) *MonotonicCounterUint {
+	return &MonotonicCounterUint{nil, writer, buildLinePrefix("U", name, tags, commonTags)}
+}
+
+// MeterId returns the meter identifier, reconstructing it from the line prefix
+// if the counter was created directly from a name and tags.
 func (c *MonotonicCounterUint) MeterId() *Id {
-	return c.id
+	return resolveMeterId(c.id, c.linePrefix)
 }
 
 // Set sets a value as the current measurement; spectatord calculates the delta.
 func (c *MonotonicCounterUint) Set(value uint64) {
-	c.writer.Write(c.linePrefix + strconv.FormatUint(value, 10))
+	c.writer.WriteUint(c.linePrefix, value)
 }

--- a/spectator/meter/percentile_distsummary.go
+++ b/spectator/meter/percentile_distsummary.go
@@ -1,8 +1,6 @@
 package meter
 
 import (
-	"strconv"
-
 	"github.com/Netflix/spectator-go/v2/spectator/writer"
 )
 
@@ -15,7 +13,7 @@ type PercentileDistributionSummary struct {
 }
 
 func (p *PercentileDistributionSummary) MeterId() *Id {
-	return p.id
+	return resolveMeterId(p.id, p.linePrefix)
 }
 
 // NewPercentileDistributionSummary creates a new *PercentileDistributionSummary using the meter identifier.
@@ -23,9 +21,16 @@ func NewPercentileDistributionSummary(id *Id, writer writer.Writer) *PercentileD
 	return &PercentileDistributionSummary{id, writer, "D:" + id.spectatordId + ":"}
 }
 
+// NewPercentileDistributionSummaryDirect creates a new *PercentileDistributionSummary
+// directly from a name and tags, without allocating an *Id or copying the tags map.
+// commonTags carries the registry's extraCommonTags.
+func NewPercentileDistributionSummaryDirect(name string, tags, commonTags map[string]string, writer writer.Writer) *PercentileDistributionSummary {
+	return &PercentileDistributionSummary{nil, writer, buildLinePrefix("D", name, tags, commonTags)}
+}
+
 // Record records an amount to track within the distribution.
 func (p *PercentileDistributionSummary) Record(amount int64) {
 	if amount >= 0 {
-		p.writer.Write(p.linePrefix + strconv.FormatInt(amount, 10))
+		p.writer.WriteInt(p.linePrefix, amount)
 	}
 }

--- a/spectator/meter/percentile_timer.go
+++ b/spectator/meter/percentile_timer.go
@@ -1,8 +1,6 @@
 package meter
 
 import (
-	"strconv"
-
 	"github.com/Netflix/spectator-go/v2/spectator/writer"
 	"time"
 )
@@ -22,13 +20,20 @@ func NewPercentileTimer(
 	return &PercentileTimer{id, writer, "T:" + id.spectatordId + ":"}
 }
 
+// NewPercentileTimerDirect generates a new percentile timer directly from a name
+// and tags, without allocating an *Id or copying the tags map. commonTags
+// carries the registry's extraCommonTags.
+func NewPercentileTimerDirect(name string, tags, commonTags map[string]string, writer writer.Writer) *PercentileTimer {
+	return &PercentileTimer{nil, writer, buildLinePrefix("T", name, tags, commonTags)}
+}
+
 func (t *PercentileTimer) MeterId() *Id {
-	return t.id
+	return resolveMeterId(t.id, t.linePrefix)
 }
 
 // Record records the value for a single event.
 func (t *PercentileTimer) Record(amount time.Duration) {
 	if amount >= 0 {
-		t.writer.Write(t.linePrefix + strconv.FormatFloat(amount.Seconds(), 'f', 6, 64))
+		t.writer.WriteFloat(t.linePrefix, amount.Seconds())
 	}
 }

--- a/spectator/meter/timer.go
+++ b/spectator/meter/timer.go
@@ -1,8 +1,6 @@
 package meter
 
 import (
-	"strconv"
-
 	"github.com/Netflix/spectator-go/v2/spectator/writer"
 	"time"
 )
@@ -20,14 +18,22 @@ func NewTimer(id *Id, writer writer.Writer) *Timer {
 	return &Timer{id, writer, "t:" + id.spectatordId + ":"}
 }
 
-// MeterId returns the meter identifier.
+// NewTimerDirect generates a new timer directly from a name and tags, without
+// allocating an *Id or copying the tags map. commonTags carries the registry's
+// extraCommonTags.
+func NewTimerDirect(name string, tags, commonTags map[string]string, writer writer.Writer) *Timer {
+	return &Timer{nil, writer, buildLinePrefix("t", name, tags, commonTags)}
+}
+
+// MeterId returns the meter identifier, reconstructing it from the line prefix
+// if the timer was created directly from a name and tags.
 func (t *Timer) MeterId() *Id {
-	return t.id
+	return resolveMeterId(t.id, t.linePrefix)
 }
 
 // Record records the duration this specific event took.
 func (t *Timer) Record(amount time.Duration) {
 	if amount >= 0 {
-		t.writer.Write(t.linePrefix + strconv.FormatFloat(amount.Seconds(), 'f', 6, 64))
+		t.writer.WriteFloat(t.linePrefix, amount.Seconds())
 	}
 }

--- a/spectator/registry.go
+++ b/spectator/registry.go
@@ -102,7 +102,7 @@ func (r *spectatordRegistry) NewId(name string, tags map[string]string) *meter.I
 }
 
 func (r *spectatordRegistry) AgeGauge(name string, tags map[string]string) *meter.AgeGauge {
-	return meter.NewAgeGauge(r.NewId(name, tags), r.writer)
+	return meter.NewAgeGaugeDirect(name, tags, r.config.extraCommonTags, r.writer)
 }
 
 func (r *spectatordRegistry) AgeGaugeWithId(id *meter.Id) *meter.AgeGauge {
@@ -110,7 +110,7 @@ func (r *spectatordRegistry) AgeGaugeWithId(id *meter.Id) *meter.AgeGauge {
 }
 
 func (r *spectatordRegistry) Counter(name string, tags map[string]string) *meter.Counter {
-	return meter.NewCounter(r.NewId(name, tags), r.writer)
+	return meter.NewCounterDirect(name, tags, r.config.extraCommonTags, r.writer)
 }
 
 func (r *spectatordRegistry) CounterWithId(id *meter.Id) *meter.Counter {
@@ -118,7 +118,7 @@ func (r *spectatordRegistry) CounterWithId(id *meter.Id) *meter.Counter {
 }
 
 func (r *spectatordRegistry) DistributionSummary(name string, tags map[string]string) *meter.DistributionSummary {
-	return meter.NewDistributionSummary(r.NewId(name, tags), r.writer)
+	return meter.NewDistributionSummaryDirect(name, tags, r.config.extraCommonTags, r.writer)
 }
 
 func (r *spectatordRegistry) DistributionSummaryWithId(id *meter.Id) *meter.DistributionSummary {
@@ -126,7 +126,7 @@ func (r *spectatordRegistry) DistributionSummaryWithId(id *meter.Id) *meter.Dist
 }
 
 func (r *spectatordRegistry) Gauge(name string, tags map[string]string) *meter.Gauge {
-	return meter.NewGauge(r.NewId(name, tags), r.writer)
+	return meter.NewGaugeDirect(name, tags, r.config.extraCommonTags, r.writer)
 }
 
 func (r *spectatordRegistry) GaugeWithId(id *meter.Id) *meter.Gauge {
@@ -134,7 +134,7 @@ func (r *spectatordRegistry) GaugeWithId(id *meter.Id) *meter.Gauge {
 }
 
 func (r *spectatordRegistry) GaugeWithTTL(name string, tags map[string]string, duration time.Duration) *meter.Gauge {
-	return meter.NewGaugeWithTTL(r.NewId(name, tags), r.writer, duration)
+	return meter.NewGaugeDirectWithTTL(name, tags, r.config.extraCommonTags, r.writer, duration)
 }
 
 func (r *spectatordRegistry) GaugeWithIdWithTTL(id *meter.Id, duration time.Duration) *meter.Gauge {
@@ -142,7 +142,7 @@ func (r *spectatordRegistry) GaugeWithIdWithTTL(id *meter.Id, duration time.Dura
 }
 
 func (r *spectatordRegistry) MaxGauge(name string, tags map[string]string) *meter.MaxGauge {
-	return meter.NewMaxGauge(r.NewId(name, tags), r.writer)
+	return meter.NewMaxGaugeDirect(name, tags, r.config.extraCommonTags, r.writer)
 }
 
 func (r *spectatordRegistry) MaxGaugeWithId(id *meter.Id) *meter.MaxGauge {
@@ -150,7 +150,7 @@ func (r *spectatordRegistry) MaxGaugeWithId(id *meter.Id) *meter.MaxGauge {
 }
 
 func (r *spectatordRegistry) MonotonicCounter(name string, tags map[string]string) *meter.MonotonicCounter {
-	return meter.NewMonotonicCounter(r.NewId(name, tags), r.writer)
+	return meter.NewMonotonicCounterDirect(name, tags, r.config.extraCommonTags, r.writer)
 }
 
 func (r *spectatordRegistry) MonotonicCounterWithId(id *meter.Id) *meter.MonotonicCounter {
@@ -158,7 +158,7 @@ func (r *spectatordRegistry) MonotonicCounterWithId(id *meter.Id) *meter.Monoton
 }
 
 func (r *spectatordRegistry) MonotonicCounterUint(name string, tags map[string]string) *meter.MonotonicCounterUint {
-	return meter.NewMonotonicCounterUint(r.NewId(name, tags), r.writer)
+	return meter.NewMonotonicCounterUintDirect(name, tags, r.config.extraCommonTags, r.writer)
 }
 
 func (r *spectatordRegistry) MonotonicCounterUintWithId(id *meter.Id) *meter.MonotonicCounterUint {
@@ -166,7 +166,7 @@ func (r *spectatordRegistry) MonotonicCounterUintWithId(id *meter.Id) *meter.Mon
 }
 
 func (r *spectatordRegistry) PercentileDistributionSummary(name string, tags map[string]string) *meter.PercentileDistributionSummary {
-	return meter.NewPercentileDistributionSummary(r.NewId(name, tags), r.writer)
+	return meter.NewPercentileDistributionSummaryDirect(name, tags, r.config.extraCommonTags, r.writer)
 }
 
 func (r *spectatordRegistry) PercentileDistributionSummaryWithId(id *meter.Id) *meter.PercentileDistributionSummary {
@@ -174,7 +174,7 @@ func (r *spectatordRegistry) PercentileDistributionSummaryWithId(id *meter.Id) *
 }
 
 func (r *spectatordRegistry) PercentileTimer(name string, tags map[string]string) *meter.PercentileTimer {
-	return meter.NewPercentileTimer(r.NewId(name, tags), r.writer)
+	return meter.NewPercentileTimerDirect(name, tags, r.config.extraCommonTags, r.writer)
 }
 
 func (r *spectatordRegistry) PercentileTimerWithId(id *meter.Id) *meter.PercentileTimer {
@@ -182,7 +182,7 @@ func (r *spectatordRegistry) PercentileTimerWithId(id *meter.Id) *meter.Percenti
 }
 
 func (r *spectatordRegistry) Timer(name string, tags map[string]string) *meter.Timer {
-	return meter.NewTimer(r.NewId(name, tags), r.writer)
+	return meter.NewTimerDirect(name, tags, r.config.extraCommonTags, r.writer)
 }
 
 func (r *spectatordRegistry) TimerWithId(id *meter.Id) *meter.Timer {

--- a/spectator/registry_test.go
+++ b/spectator/registry_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/Netflix/spectator-go/v2/spectator/logger"
 	"github.com/Netflix/spectator-go/v2/spectator/writer"
+	"strings"
 	"testing"
 	"time"
 )
@@ -69,6 +70,46 @@ func TestRegistryWithMemoryWriter_CounterWithId(t *testing.T) {
 	expected := "c:test_counter,extra-tag=foo:1"
 	if len(mw.Lines()) != 1 || mw.Lines()[0] != expected {
 		t.Errorf("Expected '%s', got '%s'", expected, mw.Lines()[0])
+	}
+}
+
+// TestRegistryWithMemoryWriter_CounterCommonTags guards against the name+tags
+// registry path dropping extraCommonTags (which the *WithId tests cover but the
+// name+tags tests, using a registry without common tags, did not).
+func TestRegistryWithMemoryWriter_CounterCommonTags(t *testing.T) {
+	r := NewTestRegistryWithCommonTags()
+	mw := r.GetWriter().(*writer.MemoryWriter)
+
+	r.Counter("test_counter", nil).Increment()
+
+	expected := "c:test_counter,extra-tag=foo:1"
+	if len(mw.Lines()) != 1 || mw.Lines()[0] != expected {
+		t.Errorf("Expected '%s', got '%v'", expected, mw.Lines())
+	}
+}
+
+// TestRegistryWithMemoryWriter_CounterCommonTagsMerge verifies caller tags and
+// common tags are merged on the name+tags path, with common tags winning on a
+// key collision (matching the WithId/NewId behavior).
+func TestRegistryWithMemoryWriter_CounterCommonTagsMerge(t *testing.T) {
+	config, _ := NewConfig("memory", map[string]string{"extra-tag": "common", "region": "us-east-1"}, logger.NewDefaultLogger())
+	r, _ := NewRegistry(config)
+	mw := r.GetWriter().(*writer.MemoryWriter)
+
+	// "extra-tag" collides with a common tag (common wins); "app" is caller-only.
+	r.Counter("test_counter", map[string]string{"app": "foo", "extra-tag": "caller"}).Increment()
+
+	if len(mw.Lines()) != 1 {
+		t.Fatalf("expected 1 line, got %v", mw.Lines())
+	}
+	got := mw.Lines()[0]
+	for _, want := range []string{"c:test_counter", ",app=foo", ",extra-tag=common", ",region=us-east-1", ":1"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("line %q missing %q", got, want)
+		}
+	}
+	if strings.Contains(got, "extra-tag=caller") {
+		t.Errorf("common tag should win over caller tag, got %q", got)
 	}
 }
 

--- a/spectator/writer/file_writer.go
+++ b/spectator/writer/file_writer.go
@@ -24,6 +24,22 @@ func (f *FileWriter) Write(line string) {
 	f.WriteString(line)
 }
 
+func (f *FileWriter) WriteLine(prefix, value string) {
+	f.WriteString(prefix + value)
+}
+
+func (f *FileWriter) WriteInt(prefix string, value int64) {
+	f.WriteString(formatLineInt(prefix, value))
+}
+
+func (f *FileWriter) WriteUint(prefix string, value uint64) {
+	f.WriteString(formatLineUint(prefix, value))
+}
+
+func (f *FileWriter) WriteFloat(prefix string, value float64) {
+	f.WriteString(formatLineFloat(prefix, value))
+}
+
 func (f *FileWriter) WriteBytes(line []byte) {
 	f.WriteString(string(line))
 }

--- a/spectator/writer/line_buffer.go
+++ b/spectator/writer/line_buffer.go
@@ -43,12 +43,74 @@ func (lb *LineBuffer) Write(line string) {
 	lb.mu.Lock()
 	defer lb.mu.Unlock()
 
+	lb.beginLineLocked()
+	lb.buffer.WriteString(line)
+	lb.endLineLocked()
+}
+
+func (lb *LineBuffer) WriteLine(prefix, value string) {
+	lb.mu.Lock()
+	defer lb.mu.Unlock()
+
+	lb.beginLineLocked()
+	lb.buffer.WriteString(prefix)
+	lb.buffer.WriteString(value)
+	lb.endLineLocked()
+}
+
+// WriteInt appends prefix + the base-10 value, formatting the value into a stack
+// buffer to avoid a value-string allocation. Formatting is done before taking
+// the lock so the mutex only covers the buffer appends.
+func (lb *LineBuffer) WriteInt(prefix string, value int64) {
+	var tmp [intFmtBufLen]byte
+	v := strconv.AppendInt(tmp[:0], value, 10)
+
+	lb.mu.Lock()
+	defer lb.mu.Unlock()
+	lb.beginLineLocked()
+	lb.buffer.WriteString(prefix)
+	lb.buffer.Write(v)
+	lb.endLineLocked()
+}
+
+// WriteUint appends prefix + the base-10 value.
+func (lb *LineBuffer) WriteUint(prefix string, value uint64) {
+	var tmp [intFmtBufLen]byte
+	v := strconv.AppendUint(tmp[:0], value, 10)
+
+	lb.mu.Lock()
+	defer lb.mu.Unlock()
+	lb.beginLineLocked()
+	lb.buffer.WriteString(prefix)
+	lb.buffer.Write(v)
+	lb.endLineLocked()
+}
+
+// WriteFloat appends prefix + the value formatted as 'f' with 6 decimals.
+func (lb *LineBuffer) WriteFloat(prefix string, value float64) {
+	var tmp [floatFmtBufLen]byte
+	v := strconv.AppendFloat(tmp[:0], value, 'f', 6, 64)
+
+	lb.mu.Lock()
+	defer lb.mu.Unlock()
+	lb.beginLineLocked()
+	lb.buffer.WriteString(prefix)
+	lb.buffer.Write(v)
+	lb.endLineLocked()
+}
+
+// beginLineLocked writes the line separator if the buffer already holds data.
+// Callers must hold lb.mu.
+func (lb *LineBuffer) beginLineLocked() {
 	if lb.buffer.Len() > 0 {
 		// buffer has data, so add the separator to indicate the end of the previous line
 		lb.buffer.WriteString(separator)
 	}
+}
 
-	lb.buffer.WriteString(line)
+// endLineLocked accounts for the written line and flushes on overflow.
+// Callers must hold lb.mu.
+func (lb *LineBuffer) endLineLocked() {
 	lb.lineCount++
 
 	if lb.buffer.Len() >= lb.bufferSize {

--- a/spectator/writer/lowlatency_buffer.go
+++ b/spectator/writer/lowlatency_buffer.go
@@ -3,6 +3,7 @@ package writer
 import (
 	"fmt"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -38,22 +39,25 @@ type bufferShard struct {
 }
 
 // getChunkIndexForLine returns the chunkIndex that should be used for storing the line, or -1, if there is
-// an overflow and the line cannot be stored in the bufferShard.
-func (b *bufferShard) getChunkIndexForLine(line []byte) int {
-	totalWriteLength := len(line)
+// an overflow and the line cannot be stored in the bufferShard. It reports
+// whether space was reserved (true) or the data must be dropped (false); on
+// success b.chunkIndex identifies the chunk to append into (advancing it if the
+// line does not fit in the current chunk).
+func (b *bufferShard) reserveChunkForLine(lineLen int) bool {
+	totalWriteLength := lineLen
 
 	// All chunks are full for the shard, drop the data
 	if b.chunkIndex >= len(b.data) {
 		b.overflows++
 		b.overflowBytes += int64(totalWriteLength)
-		return -1
+		return false
 	}
 
 	// This should not happen, drop the data. The maximum length of a well-formed protocol line is 3.8KB.
-	if len(line) > chunkSize {
+	if lineLen > chunkSize {
 		b.overflows++
 		b.overflowBytes += int64(totalWriteLength)
-		return -1
+		return false
 	}
 
 	if len(b.data[b.chunkIndex]) > 0 {
@@ -70,10 +74,10 @@ func (b *bufferShard) getChunkIndexForLine(line []byte) int {
 	if b.chunkIndex == len(b.data) {
 		b.overflows++
 		b.overflowBytes += int64(totalWriteLength)
-		return -1
+		return false
 	}
 
-	return b.chunkIndex
+	return true
 }
 
 type LowLatencyBuffer struct {
@@ -150,18 +154,110 @@ func NewLowLatencyBuffer(writer Writer, logger logger.Logger, bufferSize int, fl
 }
 
 func (llb *LowLatencyBuffer) Write(line string) {
-	// Pick a shard deterministically by meter id only for order-sensitive meter types.
-	// Other lines use round-robin distribution to preserve write throughput for hot meters.
-	shardIndex := llb.shardIndexFor(line)
-	lineBytes := []byte(line)
+	// A whole line shards on itself (the meter id lies between its first and last
+	// ':'); appending it with an empty value reuses the shared string append path.
+	llb.writeSegments(line, "")
+}
 
+// WriteLine appends prefix + value as one protocol line without concatenating
+// them first. Sharding uses the prefix alone: the meter id (which determines
+// the shard for order-sensitive types) lies between the first and last ':' of
+// the line, both of which are contained in the prefix, so the value never
+// affects shard selection.
+func (llb *LowLatencyBuffer) WriteLine(prefix, value string) {
+	llb.writeSegments(prefix, value)
+}
+
+// WriteInt appends prefix + the base-10 value with no allocation: the value is
+// formatted into a stack buffer and copied straight into the shard chunk.
+func (llb *LowLatencyBuffer) WriteInt(prefix string, value int64) {
+	var tmp [intFmtBufLen]byte
+	llb.writeValueSegments(prefix, strconv.AppendInt(tmp[:0], value, 10))
+}
+
+// WriteUint appends prefix + the base-10 value with no allocation.
+func (llb *LowLatencyBuffer) WriteUint(prefix string, value uint64) {
+	var tmp [intFmtBufLen]byte
+	llb.writeValueSegments(prefix, strconv.AppendUint(tmp[:0], value, 10))
+}
+
+// WriteFloat appends prefix + the value formatted as 'f' with 6 decimals, no allocation.
+func (llb *LowLatencyBuffer) WriteFloat(prefix string, value float64) {
+	var tmp [floatFmtBufLen]byte
+	llb.writeValueSegments(prefix, strconv.AppendFloat(tmp[:0], value, 'f', 6, 64))
+}
+
+// writeSegments appends prefix followed by value (both strings) as one protocol
+// line, retrying if the active buffer set is swapped out mid-write. Sharding is
+// by prefix (see WriteLine).
+func (llb *LowLatencyBuffer) writeSegments(prefix, value string) {
+	shardIndex := llb.shardIndexFor(prefix)
 	for {
 		state := llb.activeBufferState.Load()
 		buffer := llb.bufferShardForState(state, shardIndex)
-		if llb.writeToActiveShard(buffer, state, lineBytes) {
+		if buffer.appendLine(&llb.activeBufferState, state, prefix, value) {
 			return
 		}
 	}
+}
+
+// writeValueSegments is writeSegments for a value that arrives as bytes (a
+// number formatted into a caller stack buffer), so numeric emission avoids the
+// intermediate value-string allocation. value must not be retained past the
+// call; it is copied into the shard chunk under lock.
+func (llb *LowLatencyBuffer) writeValueSegments(prefix string, value []byte) {
+	shardIndex := llb.shardIndexFor(prefix)
+	for {
+		state := llb.activeBufferState.Load()
+		buffer := llb.bufferShardForState(state, shardIndex)
+		if buffer.appendLineBytes(&llb.activeBufferState, state, prefix, value) {
+			return
+		}
+	}
+}
+
+// appendLine and appendLineBytes append "prefix + value" into the shard's active
+// chunk under lock, returning false to signal a retry when the buffer set was
+// swapped after the shard was selected. They are identical except for the value
+// type (string vs []byte); Go's append accepts both, but a single generic body
+// cannot cover both core types without an allocation, so the small locked tail
+// is written twice. Keep them in sync.
+func (b *bufferShard) appendLine(state *atomic.Uint64, expected uint64, prefix, value string) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if state.Load() != expected {
+		return false
+	}
+	if !b.reserveChunkForLine(len(prefix) + len(value)) {
+		// overflows (drops) are counted in reserveChunkForLine, for metric reporting
+		return true
+	}
+	if len(b.data[b.chunkIndex]) > 0 {
+		// chunk has data, so add the separator to end the previous line
+		b.data[b.chunkIndex] = append(b.data[b.chunkIndex], separator...)
+	}
+	b.data[b.chunkIndex] = append(b.data[b.chunkIndex], prefix...)
+	b.data[b.chunkIndex] = append(b.data[b.chunkIndex], value...)
+	return true
+}
+
+func (b *bufferShard) appendLineBytes(state *atomic.Uint64, expected uint64, prefix string, value []byte) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if state.Load() != expected {
+		return false
+	}
+	if !b.reserveChunkForLine(len(prefix) + len(value)) {
+		return true
+	}
+	if len(b.data[b.chunkIndex]) > 0 {
+		b.data[b.chunkIndex] = append(b.data[b.chunkIndex], separator...)
+	}
+	b.data[b.chunkIndex] = append(b.data[b.chunkIndex], prefix...)
+	b.data[b.chunkIndex] = append(b.data[b.chunkIndex], value...)
+	return true
 }
 
 func (llb *LowLatencyBuffer) bufferShardForState(state uint64, shardIndex int) *bufferShard {
@@ -173,31 +269,6 @@ func (llb *LowLatencyBuffer) bufferShardForState(state uint64, shardIndex int) *
 
 func frontBuffersActive(state uint64) bool {
 	return state%2 == 0
-}
-
-func (llb *LowLatencyBuffer) writeToActiveShard(buffer *bufferShard, state uint64, lineBytes []byte) bool {
-	// Add the line to the appropriate chunk in the buffer shard, or drop, if it overflows
-	buffer.mu.Lock()
-	defer buffer.mu.Unlock()
-
-	if llb.activeBufferState.Load() != state {
-		return false
-	}
-
-	// Check if current chunk can fit the new data
-	idx := buffer.getChunkIndexForLine(lineBytes)
-	if idx == -1 {
-		// overflows (drops) are counted in getChunkIndexForLine, for metric reporting
-		return true
-	}
-
-	// We can write to the selected chunk
-	if len(buffer.data[buffer.chunkIndex]) > 0 {
-		// buffer has data, so add the separator, to indicate the end of the previous line
-		buffer.data[buffer.chunkIndex] = append(buffer.data[buffer.chunkIndex], []byte(separator)...)
-	}
-	buffer.data[buffer.chunkIndex] = append(buffer.data[buffer.chunkIndex], lineBytes...)
-	return true
 }
 
 // shardIndexFor returns the shard a protocol line should be written to. Lines for the same

--- a/spectator/writer/lowlatency_buffer_test.go
+++ b/spectator/writer/lowlatency_buffer_test.go
@@ -247,7 +247,7 @@ func TestLowLatencyBuffer_RejectsStaleShardSelectionAfterSwap(t *testing.T) {
 	if !frontBuffersActive(buffer.activeBufferState.Load()) {
 		t.Fatalf("Expected front buffers to be active after two swaps")
 	}
-	if buffer.writeToActiveShard(staleShard, staleState, []byte(staleLine)) {
+	if staleShard.appendLine(&buffer.activeBufferState, staleState, staleLine, "") {
 		t.Fatal("Expected stale buffer selection to be rejected")
 	}
 

--- a/spectator/writer/lowlatency_buffer_writeline_test.go
+++ b/spectator/writer/lowlatency_buffer_writeline_test.go
@@ -1,0 +1,89 @@
+package writer
+
+import (
+	"runtime"
+	"slices"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/Netflix/spectator-go/v2/spectator/logger"
+)
+
+// TestLowLatencyBuffer_WriteLineMatchesWrite verifies that WriteLine(prefix, value)
+// flushes byte-identical output to Write(prefix + value), across commutative and
+// order-sensitive meter types (which take different shard-selection paths).
+func TestLowLatencyBuffer_WriteLineMatchesWrite(t *testing.T) {
+	cases := []struct{ prefix, value string }{
+		{"c:hot.counter:", "1"},                 // commutative counter
+		{"c:hot.counter,app=foo,zone=z:", "42"}, // counter with tags
+		{"g:hot.gauge:", "3.14"},                // order-sensitive gauge
+		{"g,120:ttl.gauge:", "7"},               // order-sensitive gauge with TTL
+		{"C:mono.counter:", "5"},                // order-sensitive monotonic counter
+		{"A:age.gauge:", "0"},                   // order-sensitive age gauge
+	}
+
+	shards := runtime.NumCPU()
+	bufferSize := 2 * 2 * chunkSize * shards
+
+	collect := func(write func(b *LowLatencyBuffer)) []string {
+		mem := &MemoryWriter{}
+		buf := NewLowLatencyBuffer(mem, logger.NewDefaultLogger(), bufferSize, 5*time.Millisecond)
+		write(buf)
+		buf.Close() // flushes remaining data
+		lines := splitAndFilterMetricLines(mem)
+		slices.Sort(lines)
+		return lines
+	}
+
+	viaWrite := collect(func(b *LowLatencyBuffer) {
+		for _, c := range cases {
+			b.Write(c.prefix + c.value)
+		}
+	})
+	viaWriteLine := collect(func(b *LowLatencyBuffer) {
+		for _, c := range cases {
+			b.WriteLine(c.prefix, c.value)
+		}
+	})
+
+	if !slices.Equal(viaWrite, viaWriteLine) {
+		t.Fatalf("WriteLine output differs from Write output:\n Write:     %q\n WriteLine: %q", viaWrite, viaWriteLine)
+	}
+}
+
+// TestLowLatencyBuffer_TypedWritesMatchWrite verifies that WriteInt / WriteUint /
+// WriteFloat produce output identical to the equivalent Write(prefix + strconv.Format...).
+func TestLowLatencyBuffer_TypedWritesMatchWrite(t *testing.T) {
+	shards := runtime.NumCPU()
+	bufferSize := 2 * 2 * chunkSize * shards
+
+	collect := func(write func(b *LowLatencyBuffer)) []string {
+		mem := &MemoryWriter{}
+		buf := NewLowLatencyBuffer(mem, logger.NewDefaultLogger(), bufferSize, 5*time.Millisecond)
+		write(buf)
+		buf.Close()
+		lines := splitAndFilterMetricLines(mem)
+		slices.Sort(lines)
+		return lines
+	}
+
+	viaWrite := collect(func(b *LowLatencyBuffer) {
+		b.Write("c:my.counter:" + strconv.FormatInt(42, 10))
+		b.Write("c:my.counter:" + strconv.FormatInt(-7, 10))
+		b.Write("U:mono.uint:" + strconv.FormatUint(18446744073709551615, 10))
+		b.Write("g:my.gauge:" + strconv.FormatFloat(3.14159, 'f', 6, 64))
+		b.Write("t:my.timer:" + strconv.FormatFloat(0.001234, 'f', 6, 64))
+	})
+	viaTyped := collect(func(b *LowLatencyBuffer) {
+		b.WriteInt("c:my.counter:", 42)
+		b.WriteInt("c:my.counter:", -7)
+		b.WriteUint("U:mono.uint:", 18446744073709551615)
+		b.WriteFloat("g:my.gauge:", 3.14159)
+		b.WriteFloat("t:my.timer:", 0.001234)
+	})
+
+	if !slices.Equal(viaWrite, viaTyped) {
+		t.Fatalf("typed writes differ from Write output:\n Write: %q\n Typed: %q", viaWrite, viaTyped)
+	}
+}

--- a/spectator/writer/memory_writer.go
+++ b/spectator/writer/memory_writer.go
@@ -15,6 +15,22 @@ func (m *MemoryWriter) Write(line string) {
 	m.WriteString(line)
 }
 
+func (m *MemoryWriter) WriteLine(prefix, value string) {
+	m.WriteString(prefix + value)
+}
+
+func (m *MemoryWriter) WriteInt(prefix string, value int64) {
+	m.WriteString(formatLineInt(prefix, value))
+}
+
+func (m *MemoryWriter) WriteUint(prefix string, value uint64) {
+	m.WriteString(formatLineUint(prefix, value))
+}
+
+func (m *MemoryWriter) WriteFloat(prefix string, value float64) {
+	m.WriteString(formatLineFloat(prefix, value))
+}
+
 func (m *MemoryWriter) WriteBytes(line []byte) {
 	m.WriteString(string(line))
 }

--- a/spectator/writer/noop_writer.go
+++ b/spectator/writer/noop_writer.go
@@ -5,6 +5,14 @@ type NoopWriter struct{}
 
 func (n *NoopWriter) Write(_ string) {}
 
+func (n *NoopWriter) WriteLine(_, _ string) {}
+
+func (n *NoopWriter) WriteInt(_ string, _ int64) {}
+
+func (n *NoopWriter) WriteUint(_ string, _ uint64) {}
+
+func (n *NoopWriter) WriteFloat(_ string, _ float64) {}
+
 func (n *NoopWriter) WriteBytes(_ []byte) {}
 
 func (n *NoopWriter) WriteString(_ string) {}

--- a/spectator/writer/stderr_writer.go
+++ b/spectator/writer/stderr_writer.go
@@ -12,6 +12,22 @@ func (s *StderrWriter) Write(line string) {
 	s.WriteString(line)
 }
 
+func (s *StderrWriter) WriteLine(prefix, value string) {
+	s.WriteString(prefix + value)
+}
+
+func (s *StderrWriter) WriteInt(prefix string, value int64) {
+	s.WriteString(formatLineInt(prefix, value))
+}
+
+func (s *StderrWriter) WriteUint(prefix string, value uint64) {
+	s.WriteString(formatLineUint(prefix, value))
+}
+
+func (s *StderrWriter) WriteFloat(prefix string, value float64) {
+	s.WriteString(formatLineFloat(prefix, value))
+}
+
 func (s *StderrWriter) WriteBytes(line []byte) {
 	s.WriteString(string(line))
 }

--- a/spectator/writer/stdout_writer.go
+++ b/spectator/writer/stdout_writer.go
@@ -12,6 +12,22 @@ func (s *StdoutWriter) Write(line string) {
 	s.WriteString(line)
 }
 
+func (s *StdoutWriter) WriteLine(prefix, value string) {
+	s.WriteString(prefix + value)
+}
+
+func (s *StdoutWriter) WriteInt(prefix string, value int64) {
+	s.WriteString(formatLineInt(prefix, value))
+}
+
+func (s *StdoutWriter) WriteUint(prefix string, value uint64) {
+	s.WriteString(formatLineUint(prefix, value))
+}
+
+func (s *StdoutWriter) WriteFloat(prefix string, value float64) {
+	s.WriteString(formatLineFloat(prefix, value))
+}
+
 func (s *StdoutWriter) WriteBytes(line []byte) {
 	s.WriteString(string(line))
 }

--- a/spectator/writer/udp_writer.go
+++ b/spectator/writer/udp_writer.go
@@ -66,6 +66,57 @@ func (u *UdpWriter) Write(line string) {
 	u.WriteString(line)
 }
 
+func (u *UdpWriter) WriteLine(prefix, value string) {
+	if u.lineBuffer != nil {
+		u.lineBuffer.WriteLine(prefix, value)
+		return
+	}
+
+	if u.lowLatencyBuffer != nil {
+		u.lowLatencyBuffer.WriteLine(prefix, value)
+		return
+	}
+
+	// Direct writes need a single contiguous datagram, so concatenate here.
+	u.WriteString(prefix + value)
+}
+
+func (u *UdpWriter) WriteInt(prefix string, value int64) {
+	if u.lineBuffer != nil {
+		u.lineBuffer.WriteInt(prefix, value)
+		return
+	}
+	if u.lowLatencyBuffer != nil {
+		u.lowLatencyBuffer.WriteInt(prefix, value)
+		return
+	}
+	u.WriteString(formatLineInt(prefix, value))
+}
+
+func (u *UdpWriter) WriteUint(prefix string, value uint64) {
+	if u.lineBuffer != nil {
+		u.lineBuffer.WriteUint(prefix, value)
+		return
+	}
+	if u.lowLatencyBuffer != nil {
+		u.lowLatencyBuffer.WriteUint(prefix, value)
+		return
+	}
+	u.WriteString(formatLineUint(prefix, value))
+}
+
+func (u *UdpWriter) WriteFloat(prefix string, value float64) {
+	if u.lineBuffer != nil {
+		u.lineBuffer.WriteFloat(prefix, value)
+		return
+	}
+	if u.lowLatencyBuffer != nil {
+		u.lowLatencyBuffer.WriteFloat(prefix, value)
+		return
+	}
+	u.WriteString(formatLineFloat(prefix, value))
+}
+
 func (u *UdpWriter) WriteBytes(line []byte) {
 	_, err := u.conn.Write(line)
 	if err != nil {

--- a/spectator/writer/unixgram_writer.go
+++ b/spectator/writer/unixgram_writer.go
@@ -20,7 +20,7 @@ type unixgramBufferWriter struct {
 }
 
 func NewUnixgramWriter(path string, logger logger.Logger) (*UnixgramWriter, error) {
-	return NewUnixgramWriterWithBuffer(path, logger, 0, 5 * time.Second)
+	return NewUnixgramWriterWithBuffer(path, logger, 0, 5*time.Second)
 }
 
 func NewUnixgramWriterWithBuffer(path string, logger logger.Logger, bufferSize int, flushInterval time.Duration) (*UnixgramWriter, error) {
@@ -64,6 +64,57 @@ func (u *UnixgramWriter) Write(line string) {
 	}
 
 	u.WriteString(line)
+}
+
+func (u *UnixgramWriter) WriteLine(prefix, value string) {
+	if u.lineBuffer != nil {
+		u.lineBuffer.WriteLine(prefix, value)
+		return
+	}
+
+	if u.lowLatencyBuffer != nil {
+		u.lowLatencyBuffer.WriteLine(prefix, value)
+		return
+	}
+
+	// Direct writes need a single contiguous datagram, so concatenate here.
+	u.WriteString(prefix + value)
+}
+
+func (u *UnixgramWriter) WriteInt(prefix string, value int64) {
+	if u.lineBuffer != nil {
+		u.lineBuffer.WriteInt(prefix, value)
+		return
+	}
+	if u.lowLatencyBuffer != nil {
+		u.lowLatencyBuffer.WriteInt(prefix, value)
+		return
+	}
+	u.WriteString(formatLineInt(prefix, value))
+}
+
+func (u *UnixgramWriter) WriteUint(prefix string, value uint64) {
+	if u.lineBuffer != nil {
+		u.lineBuffer.WriteUint(prefix, value)
+		return
+	}
+	if u.lowLatencyBuffer != nil {
+		u.lowLatencyBuffer.WriteUint(prefix, value)
+		return
+	}
+	u.WriteString(formatLineUint(prefix, value))
+}
+
+func (u *UnixgramWriter) WriteFloat(prefix string, value float64) {
+	if u.lineBuffer != nil {
+		u.lineBuffer.WriteFloat(prefix, value)
+		return
+	}
+	if u.lowLatencyBuffer != nil {
+		u.lowLatencyBuffer.WriteFloat(prefix, value)
+		return
+	}
+	u.WriteString(formatLineFloat(prefix, value))
 }
 
 func (u *UnixgramWriter) WriteBytes(line []byte) {
@@ -121,7 +172,6 @@ func (u *UnixgramWriter) redialSocket() {
 		u.conn = conn
 	}
 }
-
 
 func (u *UnixgramWriter) Close() error {
 	// Stop flush timer, and flush remaining lines

--- a/spectator/writer/writer.go
+++ b/spectator/writer/writer.go
@@ -3,14 +3,57 @@ package writer
 import (
 	"fmt"
 	"github.com/Netflix/spectator-go/v2/spectator/logger"
+	"strconv"
 	"strings"
 	"time"
 )
+
+// intFmtBufLen is enough for any base-10 int64/uint64: min int64
+// "-9223372036854775808" and max uint64 "18446744073709551615" are both 20 bytes.
+const intFmtBufLen = 20
+
+// floatFmtBufLen is the largest output strconv.AppendFloat can produce for a
+// float64 in 'f' format with 6 decimals: sign + up to 309 integer digits
+// (math.MaxFloat64 ≈ 1.8e308) + '.' + 6 fractional digits. Sizing the scratch
+// buffer to this keeps WriteFloat allocation-free for the full float64 range.
+const floatFmtBufLen = 1 + 309 + 1 + 6
+
+// formatLineInt, formatLineUint, and formatLineFloat build a full protocol line
+// from a prefix and numeric value. They are the concatenating fallback used by
+// non-buffered writers, which need a single contiguous line anyway; buffered
+// writers override the typed methods to append without allocating.
+func formatLineInt(prefix string, value int64) string {
+	return prefix + strconv.FormatInt(value, 10)
+}
+
+func formatLineUint(prefix string, value uint64) string {
+	return prefix + strconv.FormatUint(value, 10)
+}
+
+func formatLineFloat(prefix string, value float64) string {
+	return prefix + strconv.FormatFloat(value, 'f', 6, 64)
+}
 
 // Writer that accepts SpectatorD line protocol.
 type Writer interface {
 	// Write is the primary interface, for meters
 	Write(line string)
+	// WriteLine writes a protocol line composed of a precomputed prefix
+	// (e.g. "c:name,tag=val:") followed by a value (e.g. "1"), without the
+	// caller building an intermediate concatenated string. Buffered writers
+	// append the two pieces directly into their backing storage, avoiding a
+	// per-emit allocation on the metric hot path. Non-buffered writers may
+	// concatenate, which is no more expensive than the previous Write path.
+	WriteLine(prefix, value string)
+	// WriteInt, WriteUint, and WriteFloat write prefix followed by a numeric
+	// value formatted with strconv. Buffered writers format directly into their
+	// backing storage (strconv.Append*), avoiding the string allocation that a
+	// caller-side strconv.Format* + WriteLine would incur. Floats use the same
+	// format as the line protocol: 'f', 6 decimal places, 64-bit. Non-buffered
+	// writers may format-and-concatenate as a fallback.
+	WriteInt(prefix string, value int64)
+	WriteUint(prefix string, value uint64)
+	WriteFloat(prefix string, value float64)
 	// WriteBytes and WriteString are secondary interfaces, for buffers
 	WriteBytes(line []byte)
 	WriteString(line string)


### PR DESCRIPTION
Optimizes the spectator-go v2 hot paths that regressed relative to the pre-spectatord aggregating registry (v0.2.0), focused on the dominant `registry.Counter(name, tags).Increment()`-per-call pattern.

Zero-allocation emission via typed writer methods:
- Add WriteLine/WriteInt/WriteUint/WriteFloat to the writer.Writer interface and all implementations. Buffered writers append the line prefix and value directly into their backing storage (LowLatencyBuffer into its shard chunks, LineBuffer into its builder), and numeric values are formatted with strconv.Append* into a stack buffer, so emission no longer allocates the intermediate "prefix + value" string. Non-buffered writers concatenate as a fallback, no worse than the previous Write path. LowLatencyBuffer shards on the prefix alone (the meter id lies between the first and last ':', both in the prefix), equivalent to full-line sharding.

Cheaper metric-id sanitization:
- writeSanitized now byte-scans for validity and, when the input is already clean (the common case), writes it in one shot instead of a per-rune UTF-8 decode + re-encode. Byte-identical output; only clean-vs-dirty routing added.

Direct meter construction from (name, tags):
- Registry (name, tags) methods build the line prefix directly via buildLinePrefix, without allocating an *Id or copying the tags map. The meter stores only its line prefix; MeterId() reconstructs an Id on demand for the rarely-used introspection path. extraCommonTags are merged into the prefix (common tags win on key collision), so meters built this way carry the same infrastructure tags as the WithId path.

```
Measured, cached meter -> LowLatencyBuffer:
  Counter.Increment: 41 ns, 96 B, 1 alloc  -> 24 ns, 0 B, 0 allocs
  Counter.Add:       59 ns, 119 B, 2 allocs -> 33 ns, 0 B, 0 allocs
  Gauge.Set/Timer.Record/DistSummary.Record likewise reach 0 allocs.

Measured, construct-per-call (registry.Counter(name,tags).Increment()):
  v2 before: 544 ns, 5 allocs
  v2 now:    175 ns, 2 allocs (via registry)
  v0.2.0:    384 ns, 6 allocs
so v2 is now faster than the version the pattern regressed from, with no
registry meter cache.
```

Notes:
- Adds methods to the exported writer.Writer interface: a breaking change for any external Writer implementation (there is no supported way to inject a custom Writer, so in-tree impact is nil). Worth a release-note callout.
- MeterId() on meters built via the (name, tags) path returns an Id whose name/tags are the sanitized, prefix-reconstructed forms (lossy for unclean input) rather than the caller's originals.

Includes end-to-end emit benchmarks and correctness tests: WriteLine/typed output is byte-identical to Write(prefix+value); direct-vs-WithId identity matches; and the (name, tags) path preserves common tags (with merge/override).